### PR TITLE
Api doc sync

### DIFF
--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -2,12 +2,11 @@ name: Push code located in`bci_essentials` to ` APIdocs-for-bci-essentials-pytho
 
 on:
   push:
-    branches:
-      # - main
-      - api-doc-sync
+    # branches: ["main"]
+    branches: ["api-doc-sync"]
 
 jobs:
-  sync:
+  push_code:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Push code to the `APIdocs` repository
-        uses: nkoppel/push-files-to-another-repository@1.1.0
+        uses: nkoppel/push-files-to-another-repository@1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.APIdocs_sync }}
         with:

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -21,5 +21,6 @@ jobs:
           source-files: 'bci_essentials/'
           destination-username: 'kirtonBCIlab'
           destination-repository: 'APIdocs-for-bci-essentials-python'
+          destination-branch: 'main'
           destination-directory: './'
           commit-email: 'n44412824+anup2ladder@users.noreply.github.com'

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -1,4 +1,6 @@
-name: Push code located in`bci_essentials` to ` APIdocs-for-bci-essentials-python` repo on push to `main`
+name: Push code to APIdocs repo
+# Push the code folder `bci_essentials` to the
+# ` APIdocs-for-bci-essentials-python` repo on push to `main`
 
 on:
   push:
@@ -18,9 +20,10 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.APIDOCS_SYNC }}
         with:
-          source-files: 'bci_essentials/'
+          source-files: 'bci_essentials/ environment.yml'
           destination-username: 'kirtonBCIlab'
           destination-repository: 'APIdocs-for-bci-essentials-python'
           destination-branch: 'main'
           destination-directory: './'
+          commit-message: "Copy bci_essentials code directory on push to UPSTREAM/main"
           commit-email: 'n44412824+anup2ladder@users.noreply.github.com'

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -1,0 +1,26 @@
+name: Push code located in`bci_essentials` to ` APIdocs-for-bci-essentials-python` repo on push to `main`
+
+on:
+  push:
+    branches:
+      # - main
+      - api-doc-sync
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout SOURCE repository
+        uses: actions/checkout@v2
+
+      - name: Push code to the `APIdocs` repository
+        uses: nkoppel/push-files-to-another-repository@1.1.0
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.APIdocs_sync }}
+        with:
+          source-files: 'bci_essentials/'
+          destination-username: 'kirtonBCIlab'
+          destination-repository: 'APIdocs-for-bci-essentials-python'
+          destination-directory: './'
+          commit-email: 'n44412824+anup2ladder@users.noreply.github.com'

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -5,8 +5,7 @@ name: Push code to APIdocs repo
 
 on:
   push:
-    # branches: ["main"]
-    branches: ["api-doc-sync"]
+    branches: ["main"]
 
 jobs:
   push_code:

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout SOURCE repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Push code to the `APIdocs` repository
         uses: nkoppel/push-files-to-another-repository@v1.1.1

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -1,6 +1,7 @@
 name: Push code to APIdocs repo
-# Push the code folder `bci_essentials` to the
-# ` APIdocs-for-bci-essentials-python` repo on push to `main`
+# This Github action executes on push to `main`
+# and Pushes the code folder `bci_essentials` to the
+# ` APIdocs-for-bci-essentials-python` repo.
 
 on:
   push:

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.APIDOCS_SYNC }}
         with:
-          source-files: 'bci_essentials/ environment.yml'
+          source-files: 'bci_essentials/ environment.yml pyproject.toml'
           destination-username: 'kirtonBCIlab'
           destination-repository: 'APIdocs-for-bci-essentials-python'
           destination-branch: 'main'

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Push code to the `APIdocs` repository
         uses: nkoppel/push-files-to-another-repository@1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.APIdocs_sync }}
+          API_TOKEN_GITHUB: ${{ secrets.APIDOCS_SYNC }}
         with:
           source-files: 'bci_essentials/'
           destination-username: 'kirtonBCIlab'

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Push code to the `APIdocs` repository
-        uses: nkoppel/push-files-to-another-repository@1.1.1
+        uses: nkoppel/push-files-to-another-repository@v1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.APIDOCS_SYNC }}
         with:


### PR DESCRIPTION
Set-up a github action that uses the [nkoppel/push-files-to-another-repository](https://github.com/marketplace/actions/copy-files-to-another-repository) action to copy the `bci-essentials` code directory to the [APIdocs-for-bci-essentials-python](https://github.com/kirtonBCIlab/APIdocs-for-bci-essentials-python) on push to `main` of `bci-essentials-python`. Additionally, `environment.yml` and `pyproject.toml` are also copied.