### PR TITLE
Fixed incorrect import statement of Generic_classifier

### DIFF
--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -19,7 +19,7 @@ from pyriemann.estimation import Covariances
 from pyriemann.classification import MDM, TSclassifier
 from pyriemann.channelselection import FlatChannelRemover, ElectrodeSelection
 
-from classification.generic_classifier import Generic_classifier
+from bci_essentials.classification import Generic_classifier
 
 from bci_essentials.channel_selection import channel_selection_by_method
 

--- a/bci_essentials/classification/null_classifier.py
+++ b/bci_essentials/classification/null_classifier.py
@@ -10,7 +10,7 @@ The classifier always predicts 0.
 import os
 import sys
 
-from classification.generic_classifier import Generic_classifier
+from bci_essentials.classification import Generic_classifier
 
 # Custom libraries
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir))

--- a/bci_essentials/classification/ssvep_basic_tf_classifier.py
+++ b/bci_essentials/classification/ssvep_basic_tf_classifier.py
@@ -10,7 +10,7 @@ import sys
 import numpy as np
 from scipy import signal
 
-from classification.generic_classifier import Generic_classifier
+from bci_essentials.classification import Generic_classifier
 
 # from bci_essentials.visuals import *
 # from bci_essentials.signal_processing import *

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -16,7 +16,7 @@ from sklearn.metrics import confusion_matrix, precision_score, recall_score
 from pyriemann.classification import MDM
 from pyriemann.estimation import Covariances
 
-from classification.generic_classifier import Generic_classifier
+from bci_essentials.classification import Generic_classifier
 
 # from bci_essentials.visuals import *
 from bci_essentials.signal_processing import bandpass

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -21,7 +21,7 @@ from sklearn.metrics import confusion_matrix, accuracy_score
 from sklearn import preprocessing
 import tensorflow as tf
 
-from classification.generic_classifier import Generic_classifier
+from bci_essentials.classification import Generic_classifier
 
 # Custom libraries
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir))

--- a/bci_essentials/classification/switch_mdm_classifier.py
+++ b/bci_essentials/classification/switch_mdm_classifier.py
@@ -21,7 +21,7 @@ from sklearn.pipeline import Pipeline
 from sklearn import preprocessing
 from pyriemann.classification import MDM
 
-from classification.generic_classifier import Generic_classifier
+from bci_essentials.classification import Generic_classifier
 
 # Custom libraries
 # - Append higher directory to import bci_essentials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bci-essentials"
-version = "0.0.6"
+version = "0.0.7"
 description = "Python backend for bci-essentials"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
In the modified classification submodules, changed the line:

`from classification.generic_classifier import Generic_classifier`

TO

`from bci_essentials.classification import Generic_classifier`