### PR TITLE
Update signal_processing.py

### DIFF
--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -101,7 +101,7 @@ def lowpass(data, f_critical, order, fsample):
 
         shape = (P, N, M) or (N, M)
     """
-    Wn = [f_critical / (fsample / 2)]
+    Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="lowpass")
 
     try:
@@ -152,7 +152,7 @@ def highpass(data, f_critical, order, fsample):
 
         shape = (P, N, M) or (N, M)
     """
-    Wn = [f_critical / (fsample / 2)]
+    Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="highpass")
 
     try:


### PR DESCRIPTION
Fixes the deprecation warning. Issue was that scipy was getting a list containing a single float instead of a single float.