### PR TITLE
Provide probabilities with predicted class labels

### DIFF
--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -384,3 +384,22 @@ class ErpRgClassifier(GenericClassifier):
         if plot_roc:
             logger.info("Plotting the ROC...")
             logger.error("Just kidding ROC has not been implemented")
+
+    def predict(self, X):
+        """Predict the class of the data (Unused in this classifier)
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            3D array where shape = (windows, channels, samples)
+
+        Returns
+        -------
+        prediction : numpy.ndarray
+            1D array containing the predicted class labels.
+
+        probability : numpy.ndarray
+            1D array containing probability of the predicted class label
+
+        """
+        return [np.ndarray([]), np.ndarray([])]

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -22,7 +22,7 @@ from pyriemann.estimation import XdawnCovariances
 from pyriemann.tangentspace import TangentSpace
 
 # Import bci_essentials modules and methods
-from ..classification.generic_classifier import GenericClassifier
+from ..classification.generic_classifier import GenericClassifier, Prediction
 from ..signal_processing import lico
 from ..channel_selection import channel_selection_by_method
 from ..utils.logger import Logger  # Logger wrapper
@@ -395,11 +395,8 @@ class ErpRgClassifier(GenericClassifier):
 
         Returns
         -------
-        prediction : numpy.ndarray
-            1D array containing the predicted class labels.
-
-        probability : numpy.ndarray
-            1D array containing probability of the predicted class label
+        prediction : Prediction
+            Empty Predict object
 
         """
-        return [np.ndarray([]), np.ndarray([])]
+        return Prediction()

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -22,11 +22,13 @@ class Prediction:
     """Prediction data returned by GenericClassifer.predict()
 
     labels : list
-        list of the predicted class labels, defaluts to []
+        List of the predicted class labels.
+        - Default is `[]`.
 
     probabilities : list
-        list of probabilities for each class label, defaults to [], which
-        can be used if the clasifier can't provide probabilities.
+        List of probabilities for each class label. If the classifier can't
+        provide probabilities, this will be an empty list `[]`.
+        - Default is `[]`
 
     """
 

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -6,6 +6,7 @@ Used as Parent classifier class for other classifiers.
 
 # Stock libraries
 import numpy as np
+from abc import ABC, abstractmethod
 
 from ..utils.logger import Logger  # Logger wrapper
 
@@ -14,7 +15,7 @@ from ..utils.logger import Logger  # Logger wrapper
 logger = Logger(name=__name__)
 
 
-class GenericClassifier:
+class GenericClassifier(ABC):
     """The base generic classifier class for other classifiers."""
 
     def __init__(self, training_selection=0, subset=[]):
@@ -338,21 +339,15 @@ class GenericClassifier:
             decision_block, self.subset, self.channel_labels
         )
 
-        logger.info("Making a prediction")
-
         # get prediction probabilities for all
         proba_mat = self.clf.predict_proba(decision_block)
-
         proba = proba_mat[:, 1]
-
         relative_proba = proba / np.amax(proba)
 
         log_proba = np.log(relative_proba)
-
         logger.info("log relative probabilities:\n%s", log_proba)
 
         # the selection is the highest probability
-
         prediction = int(np.where(proba == np.amax(proba))[0][0])
 
         self.predictions.append(prediction)
@@ -360,6 +355,7 @@ class GenericClassifier:
 
         return prediction
 
+    @abstractmethod
     def fit(self):
         """Abstract method to fit classifier
 
@@ -368,9 +364,10 @@ class GenericClassifier:
         `None`
 
         """
-        return None
+        pass
 
-    def predict(self, X: np.ndarray) -> np.ndarray:
+    @abstractmethod
+    def predict(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """Abstract method to predict with classifier
 
         X : numpy.ndarray
@@ -381,5 +378,8 @@ class GenericClassifier:
         prediction : numpy.ndarray
             1D array containing the predicted class labels.
 
+        probability : numpy.ndarray
+            1D array containing probability of the predicted class label
+
         """
-        return np.ndarray([])
+        pass

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -360,14 +360,9 @@ class GenericClassifier:
 
         return prediction
 
-    def fit(self, **kwargs):
+    def fit(self):
         """Abstract method to fit classifier
 
-        Parameters
-        ----------
-        \*\*kwargs : dict, *optional*
-            Description of extra arguments to pass to the method.
-
         Returns
         -------
         `None`
@@ -375,17 +370,16 @@ class GenericClassifier:
         """
         return None
 
-    def predict(self, **kwargs):
+    def predict(self, X: np.ndarray) -> np.ndarray:
         """Abstract method to predict with classifier
 
-        Parameters
-        ----------
-        \*\*kwargs : dict, *optional*
-            Description of extra arguments to pass to the method.
+        X : numpy.ndarray
+            3D array where shape = (windows, channels, samples)
 
         Returns
         -------
-        `None`
+        prediction : numpy.ndarray
+            1D array containing the predicted class labels.
 
         """
-        return None
+        return np.ndarray([])

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -21,11 +21,12 @@ logger = Logger(name=__name__)
 class Prediction:
     """Prediction data returned by GenericClassifer.predict()
 
-    prediction : list
+    labels : list
         list of the predicted class labels, defaluts to []
 
-    probability : list
-        list of the predicted class label, defaults to []
+    probabilities : list
+        list of probabilities for each class label, defaults to [], which
+        can be used if the clasifier can't provide probabilities.
 
     """
 

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -5,14 +5,32 @@ Used as Parent classifier class for other classifiers.
 """
 
 # Stock libraries
-import numpy as np
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+import numpy as np
 
 from ..utils.logger import Logger  # Logger wrapper
 
 # Instantiate a logger for the module at the default level of logging.INFO
 # Logs to bci_essentials.__module__) where __module__ is the name of the module
 logger = Logger(name=__name__)
+
+
+@dataclass
+class Prediction:
+    """Prediction data returned by GenericClassifer.predict()
+
+    prediction : list
+        list of the predicted class labels, defaluts to []
+
+    probability : list
+        list of the predicted class label, defaults to []
+
+    """
+
+    labels: list = field(default_factory=list)
+    probabilities: list = field(default_factory=list)
 
 
 class GenericClassifier(ABC):
@@ -367,7 +385,7 @@ class GenericClassifier(ABC):
         pass
 
     @abstractmethod
-    def predict(self, X: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    def predict(self, X: np.ndarray) -> Prediction:
         """Abstract method to predict with classifier
 
         X : numpy.ndarray
@@ -375,11 +393,9 @@ class GenericClassifier(ABC):
 
         Returns
         -------
-        prediction : numpy.ndarray
-            1D array containing the predicted class labels.
-
-        probability : numpy.ndarray
-            1D array containing probability of the predicted class label
+        prediction : Prediction
+            Results of predict call containing the predicted class labels, and
+            optionally the probabilities of the labels (empty list if not possible).
 
         """
         pass

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -308,18 +308,15 @@ class MiClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            Description of parameter `X`.
-            If array, state size and type. E.g.
-            3D array containing data with `float` type.
-
-            shape = (`1st_dimension`,`2nd_dimension`,`3rd_dimension`)
+            3D array where shape = (windows, channels, samples)
 
         Returns
         -------
-        pred : numpy.ndarray
-            The predicted class labels.
+        prediction : numpy.ndarray
+            1D array containing the predicted class labels.
 
-            shape = (`1st_dimension`,)
+        probability : numpy.ndarray
+            1D array containing probability of the predicted class label
 
         """
         # if X is 2D, make it 3D with one as first dimension
@@ -342,4 +339,4 @@ class MiClassifier(GenericClassifier):
             self.predictions.append(pred[i])
             self.pred_probas.append(pred_proba[i])
 
-        return pred
+        return [pred, pred_proba]

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -18,7 +18,7 @@ from pyriemann.classification import MDM, TSclassifier
 from pyriemann.channelselection import FlatChannelRemover, ElectrodeSelection
 
 # Import bci_essentials modules and methods
-from ..classification.generic_classifier import GenericClassifier
+from ..classification.generic_classifier import GenericClassifier, Prediction
 from ..channel_selection import channel_selection_by_method
 from ..utils.logger import Logger  # Logger wrapper
 
@@ -312,11 +312,9 @@ class MiClassifier(GenericClassifier):
 
         Returns
         -------
-        prediction : numpy.ndarray
-            1D array containing the predicted class labels.
-
-        probability : numpy.ndarray
-            1D array containing probability of the predicted class label
+        prediction : Prediction
+            Results of predict call containing the predicted class labels, and
+            the probabilities of the labels.
 
         """
         # if X is 2D, make it 3D with one as first dimension
@@ -339,4 +337,4 @@ class MiClassifier(GenericClassifier):
             self.predictions.append(pred[i])
             self.pred_probas.append(pred_proba[i])
 
-        return [pred, pred_proba]
+        return Prediction(labels=pred, probabilities=pred_proba)

--- a/bci_essentials/classification/null_classifier.py
+++ b/bci_essentials/classification/null_classifier.py
@@ -7,6 +7,7 @@ The classifier always predicts 0.
 """
 
 # Stock libraries
+import numpy as np
 
 # Import bci_essentials modules and methods
 from ..classification.generic_classifier import GenericClassifier
@@ -43,10 +44,13 @@ class NullClassifier(GenericClassifier):
 
         Returns
         -------
-        pred : numpy.ndarray
-            The predicted class labels.
+        prediction : numpy.ndarray
+            1D array containing the predicted class labels.
+
+        probability : numpy.ndarray
+            1D array containing probability of the predicted class label
 
         """
         logger.warning("This is a null classifier, there is no return value")
         logger.warning("Returning 0")
-        return 0
+        return [np.ndarray([]), np.ndarray([])]

--- a/bci_essentials/classification/null_classifier.py
+++ b/bci_essentials/classification/null_classifier.py
@@ -38,15 +38,13 @@ class NullClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            Description of parameter `X`.
-            If array, state size and type. E.g.
-            3D array containing data with `float` type.
+            3D array where shape = (windows, channels, samples)
 
-            shape = (`1st_dimension`,`2nd_dimension`,`3rd_dimension`)
 
         Returns
         -------
-        `0`
+        pred : numpy.ndarray
+            The predicted class labels.
 
         """
         logger.warning("This is a null classifier, there is no return value")

--- a/bci_essentials/classification/null_classifier.py
+++ b/bci_essentials/classification/null_classifier.py
@@ -42,9 +42,9 @@ class NullClassifier(GenericClassifier):
         Returns
         -------
         prediction : Prediction
-            Empty prediction object
+            Prediction object with labels = [0]
 
         """
         logger.warning("This is a null classifier, there is no return value")
         logger.warning("Returning 0")
-        return Prediction()
+        return Prediction(labels=[0])

--- a/bci_essentials/classification/null_classifier.py
+++ b/bci_essentials/classification/null_classifier.py
@@ -6,11 +6,8 @@ The classifier always predicts 0.
 
 """
 
-# Stock libraries
-import numpy as np
-
 # Import bci_essentials modules and methods
-from ..classification.generic_classifier import GenericClassifier
+from ..classification.generic_classifier import GenericClassifier, Prediction
 from ..utils.logger import Logger  # Logger wrapper
 
 # Instantiate a logger for the module at the default level of logging.INFO
@@ -44,13 +41,10 @@ class NullClassifier(GenericClassifier):
 
         Returns
         -------
-        prediction : numpy.ndarray
-            1D array containing the predicted class labels.
-
-        probability : numpy.ndarray
-            1D array containing probability of the predicted class label
+        prediction : Prediction
+            Empty prediction object
 
         """
         logger.warning("This is a null classifier, there is no return value")
         logger.warning("Returning 0")
-        return [np.ndarray([]), np.ndarray([])]
+        return Prediction()

--- a/bci_essentials/classification/ssvep_basic_tf_classifier.py
+++ b/bci_essentials/classification/ssvep_basic_tf_classifier.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import signal
 
 # Import bci_essentials modules and methods
-from ..classification.generic_classifier import GenericClassifier
+from ..classification.generic_classifier import GenericClassifier, Prediction
 from ..utils.logger import Logger  # Logger wrapper
 
 # Instantiate a logger for the module at the default level of logging.INFO
@@ -68,11 +68,9 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
 
         Returns
         -------
-        prediction : numpy.ndarray
-            1D array containing the predicted class labels.
-
-        probability : numpy.ndarray
-            1D array containing probability of the predicted class label
+        prediction : Prediction
+            Results of predict call containing the predicted class labels.  Probabilities
+            are not available (empty list).
 
         """
         # get the shape
@@ -103,4 +101,4 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
 
             prediction[w] = np.argmax(Pxx_of_f_bins)
 
-        return [prediction, np.array([])]
+        return Prediction(labels=prediction)

--- a/bci_essentials/classification/ssvep_basic_tf_classifier.py
+++ b/bci_essentials/classification/ssvep_basic_tf_classifier.py
@@ -69,9 +69,10 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
         Returns
         -------
         prediction : numpy.ndarray
-            The predicted class labels.
+            1D array containing the predicted class labels.
 
-            shape = (`1st_dimension`,)
+        probability : numpy.ndarray
+            1D array containing probability of the predicted class label
 
         """
         # get the shape
@@ -102,4 +103,4 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
 
             prediction[w] = np.argmax(Pxx_of_f_bins)
 
-        return prediction
+        return [prediction, np.array([])]

--- a/bci_essentials/classification/ssvep_basic_tf_classifier.py
+++ b/bci_essentials/classification/ssvep_basic_tf_classifier.py
@@ -64,11 +64,7 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            Description of parameter `X`.
-            If array, state size and type. E.g.
-            3D array containing data with `float` type.
-
-            shape = (`1st_dimension`,`2nd_dimension`,`3rd_dimension`)
+            3D array where shape = (windows, channels, samples)
 
         Returns
         -------

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -15,7 +15,7 @@ from pyriemann.classification import MDM
 from pyriemann.estimation import Covariances
 
 # Import bci_essentials modules and methods
-from ..classification.generic_classifier import GenericClassifier
+from ..classification.generic_classifier import GenericClassifier, Prediction
 from ..signal_processing import bandpass
 from ..channel_selection import channel_selection_by_method
 from ..utils.logger import Logger  # Logger wrapper
@@ -339,11 +339,9 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
 
         Returns
         -------
-        prediction : numpy.ndarray
-            1D array containing the predicted class labels.
-
-        probability : numpy.ndarray
-            1D array containing probability of the predicted class label
+        prediction : Prediction
+            Results of predict call containing the predicted class labels, and
+            the probabilities of the labels.
 
         """
         # if X is 2D, make it 3D with one as first dimension
@@ -372,4 +370,4 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
             self.predictions.append(pred[i])
             self.pred_probas.append(pred_proba[i])
 
-        return [pred, pred_proba]
+        return Prediction(labels=pred, probabilities=pred_proba)

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -339,8 +339,11 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
 
         Returns
         -------
-        pred : numpy.ndarray
-            The predicted class labels.
+        prediction : numpy.ndarray
+            1D array containing the predicted class labels.
+
+        probability : numpy.ndarray
+            1D array containing probability of the predicted class label
 
         """
         # if X is 2D, make it 3D with one as first dimension
@@ -369,4 +372,4 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
             self.predictions.append(pred[i])
             self.pred_probas.append(pred_proba[i])
 
-        return pred
+        return [pred, pred_proba]

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -335,18 +335,12 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            Description of parameter `X`.
-            If array, state size and type. E.g.
-            3D array containing data with `float` type.
-
-            shape = (`1st_dimension`,`2nd_dimension`,`3rd_dimension`)
+            3D array where shape = (windows, channels, samples)
 
         Returns
         -------
         pred : numpy.ndarray
             The predicted class labels.
-
-            shape = (`1st_dimension`,)
 
         """
         # if X is 2D, make it 3D with one as first dimension

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -272,13 +272,11 @@ class SwitchDeepClassifier(GenericClassifier):
 
         Returns
         -------
-        final_string
-            Predictions formatted as strings for Unity to process it.
+        prediction : numpy.ndarray
+            1D array containing the predicted class labels.
 
-        Raises
-        ------
-        `None`
-            Error if there are not an appropriate amount of labels (three) to complete predictions on.
+        probability : numpy.ndarray
+            1D array containing probability of the predicted class label
 
         """
 
@@ -319,7 +317,7 @@ class SwitchDeepClassifier(GenericClassifier):
 
         """This will format predictions so that unity can understand them.
         However, it only works with two objects right now because of the x and y in zip"""
-
+        final_string = ""
         try:
             temp_list_new = []
             formatted_preds = []
@@ -341,10 +339,10 @@ class SwitchDeepClassifier(GenericClassifier):
             logger.info("Final predictions are: %s", final_predictions)
             logger.info("String predictions (string_peds) are: %s", final_string)
 
-            return final_string
         except Exception:
             logger.error(
                 "Error - there are not an appropriate amount of labels "
                 + "(three) to complete predictions on"
             )
-            return None
+
+        return [np.array([final_string]), np.array([])]

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -268,8 +268,7 @@ class SwitchDeepClassifier(GenericClassifier):
         Parameters
         ----------
         X : np.ndarray
-            An array that will be predicted upon by previously trained
-            models.
+            3D array where shape = (windows, channels, samples)
 
         Returns
         -------

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -275,7 +275,7 @@ class SwitchDeepClassifier(GenericClassifier):
         -------
         prediction : Prediction
             Results of predict call containing the predicted class labels.  Probabilities
-            are not available (empty list).
+            are not returned (empty list).
 
         """
 

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -20,7 +20,7 @@ from sklearn import preprocessing
 import tensorflow as tf
 
 # Import bci_essentials modules and methods
-from ..classification.generic_classifier import GenericClassifier
+from ..classification.generic_classifier import GenericClassifier, Prediction
 from ..utils.logger import Logger  # Logger wrapper
 
 # Instantiate a logger for the module at the default level of logging.INFO
@@ -272,11 +272,9 @@ class SwitchDeepClassifier(GenericClassifier):
 
         Returns
         -------
-        prediction : numpy.ndarray
-            1D array containing the predicted class labels.
-
-        probability : numpy.ndarray
-            1D array containing probability of the predicted class label
+        prediction : Prediction
+            Results of predict call containing the predicted class labels.  Probabilities
+            are not available (empty list).
 
         """
 
@@ -345,4 +343,4 @@ class SwitchDeepClassifier(GenericClassifier):
                 + "(three) to complete predictions on"
             )
 
-        return [np.array([final_string]), np.array([])]
+        return Prediction(labels=np.array([final_string]))

--- a/bci_essentials/classification/switch_mdm_classifier.py
+++ b/bci_essentials/classification/switch_mdm_classifier.py
@@ -20,7 +20,7 @@ from sklearn import preprocessing
 from pyriemann.classification import MDM
 
 # Import bci_essentials modules and methods
-from ..classification.generic_classifier import GenericClassifier
+from ..classification.generic_classifier import GenericClassifier, Prediction
 from ..utils.logger import Logger  # Logger wrapper
 
 # Instantiate a logger for the module at the default level of logging.INFO
@@ -211,11 +211,9 @@ class SwitchMdmClassifier(GenericClassifier):
 
         Returns
         -------
-        final_predictions : numpy.ndarray
-            1D array containing the predicted class labels.
-
-        probability : numpy.ndarray
-            1D array containing probability of the predicted class label
+        prediction : Prediction
+            Results of predict call containing the predicted class labels.  Probabilities
+            are not available (empty list).
 
         """
         # if X is 2D, make it 3D with one as first dimension
@@ -265,4 +263,4 @@ class SwitchMdmClassifier(GenericClassifier):
                 else:
                     np.append(final_predictions, 2)
 
-        return [final_predictions, np.array([])]
+        return Prediction(labels=final_predictions)

--- a/bci_essentials/classification/switch_mdm_classifier.py
+++ b/bci_essentials/classification/switch_mdm_classifier.py
@@ -80,9 +80,7 @@ class SwitchMdmClassifier(GenericClassifier):
         self.clf = Pipeline([("MDM", mdm)])
         # self.clf0and1 = MDM()
 
-    def fit(
-        self,
-    ):
+    def fit(self):
         """Fit the model.
 
         Returns
@@ -209,11 +207,7 @@ class SwitchMdmClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            Description of parameter `X`.
-            If array, state size and type. E.g.
-            3D array containing data with `float` type.
-
-            shape = (`1st_dimension`,`2nd_dimension`,`3rd_dimension`)
+            3D array where shape = (windows, channels, samples)
 
         Returns
         -------

--- a/bci_essentials/classification/switch_mdm_classifier.py
+++ b/bci_essentials/classification/switch_mdm_classifier.py
@@ -212,9 +212,10 @@ class SwitchMdmClassifier(GenericClassifier):
         Returns
         -------
         final_predictions : numpy.ndarray
-            The predicted class labels.
+            1D array containing the predicted class labels.
 
-            shape = (`1st_dimension`,)
+        probability : numpy.ndarray
+            1D array containing probability of the predicted class label
 
         """
         # if X is 2D, make it 3D with one as first dimension
@@ -264,4 +265,4 @@ class SwitchMdmClassifier(GenericClassifier):
                 else:
                     np.append(final_predictions, 2)
 
-        return final_predictions
+        return [final_predictions, np.array([])]

--- a/bci_essentials/eeg_data.py
+++ b/bci_essentials/eeg_data.py
@@ -802,21 +802,17 @@ class EegData:
                             )
 
                             # Make a prediction
-                            prediction, _ = self._classifier.predict(
+                            prediction = self._classifier.predict(
                                 self.current_processed_eeg_windows
                             )
 
                             logger.info(
                                 "%s was selected by the iterative classifier",
-                                prediction,
+                                prediction.labels,
                             )
 
                             if self._messenger is not None:
-                                logger.info(
-                                    "Sending prediction %s from iterative classifier",
-                                    prediction,
-                                )
-                                self._messenger.prediction(prediction)
+                                self._messenger.prediction(prediction.labels)
 
                     # PREDICT
                     elif self.train_complete and self.current_nwindows != 0:
@@ -838,19 +834,17 @@ class EegData:
 
                         # make the prediciton
                         try:
-                            prediction, _ = self._classifier.predict(
+                            prediction = self._classifier.predict(
                                 self.current_processed_eeg_windows
                             )
-                            self.online_selections.append(prediction)
+                            self.online_selections.append(prediction.labels)
 
-                            logger.info("%s was selected by classifier", prediction)
+                            logger.info(
+                                "%s was selected by classifier", prediction.labels
+                            )
 
                             if self._messenger is not None:
-                                logger.info(
-                                    "Sending prediction %s from classifier",
-                                    prediction,
-                                )
-                                self._messenger.prediction(prediction)
+                                self._messenger.prediction(prediction.labels)
 
                         except Exception:
                             logger.warning("This classification failed...")
@@ -1035,14 +1029,14 @@ class EegData:
             if self.live_update:
                 try:
                     if self.nsamples != 0:
-                        pred, _ = self._classifier.predict(
+                        pred = self._classifier.predict(
                             self.current_processed_eeg_windows[
                                 self.current_nwindows,
                                 0 : self.nchannels,
                                 0 : self.nsamples,
                             ]
                         )
-                        self._messenger.prediction(int(pred[0]))
+                        self._messenger.prediction(int(pred.labels[0]))
                 except Exception:
                     logger.error("Unable to classify this window")
 

--- a/bci_essentials/eeg_data.py
+++ b/bci_essentials/eeg_data.py
@@ -812,7 +812,7 @@ class EegData:
                             )
 
                             if self._messenger is not None:
-                                self._messenger.prediction(prediction.labels)
+                                self._messenger.prediction(prediction)
 
                     # PREDICT
                     elif self.train_complete and self.current_nwindows != 0:
@@ -844,7 +844,7 @@ class EegData:
                             )
 
                             if self._messenger is not None:
-                                self._messenger.prediction(prediction.labels)
+                                self._messenger.prediction(prediction)
 
                         except Exception:
                             logger.warning("This classification failed...")
@@ -1029,14 +1029,14 @@ class EegData:
             if self.live_update:
                 try:
                     if self.nsamples != 0:
-                        pred = self._classifier.predict(
+                        prediction = self._classifier.predict(
                             self.current_processed_eeg_windows[
                                 self.current_nwindows,
                                 0 : self.nchannels,
                                 0 : self.nsamples,
                             ]
                         )
-                        self._messenger.prediction(int(pred.labels[0]))
+                        self._messenger.prediction(prediction)
                 except Exception:
                     logger.error("Unable to classify this window")
 

--- a/bci_essentials/eeg_data.py
+++ b/bci_essentials/eeg_data.py
@@ -802,7 +802,7 @@ class EegData:
                             )
 
                             # Make a prediction
-                            prediction = self._classifier.predict(
+                            prediction, _ = self._classifier.predict(
                                 self.current_processed_eeg_windows
                             )
 
@@ -838,7 +838,7 @@ class EegData:
 
                         # make the prediciton
                         try:
-                            prediction = self._classifier.predict(
+                            prediction, _ = self._classifier.predict(
                                 self.current_processed_eeg_windows
                             )
                             self.online_selections.append(prediction)
@@ -1035,7 +1035,7 @@ class EegData:
             if self.live_update:
                 try:
                     if self.nsamples != 0:
-                        pred = self._classifier.predict(
+                        pred, _ = self._classifier.predict(
                             self.current_processed_eeg_windows[
                                 self.current_nwindows,
                                 0 : self.nchannels,

--- a/bci_essentials/io/lsl_messenger.py
+++ b/bci_essentials/io/lsl_messenger.py
@@ -1,6 +1,7 @@
 from pylsl import StreamInfo, StreamOutlet, IRREGULAR_RATE
 
 from .messenger import Messenger
+from ..classification.generic_classifier import Prediction
 
 __all__ = ["LslMessenger"]
 
@@ -32,5 +33,6 @@ class LslMessenger(Messenger):
     def marker_received(self, marker):
         self.__outlet.push_sample(["marker received : {}".format(marker)])
 
-    def prediction(self, prediction):
-        self.__outlet.push_sample(["{}".format(prediction)])
+    def prediction(self, prediction: Prediction):
+        # probability isn't used by Unity at this time
+        self.__outlet.push_sample(["{}".format(prediction.labels)])

--- a/bci_essentials/io/messenger.py
+++ b/bci_essentials/io/messenger.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from ..classification.generic_classifier import Prediction
+
 
 class Messenger(ABC):
     """A Messenger object is used by EEG_data to send event messages.  For example,
@@ -17,6 +19,6 @@ class Messenger(ABC):
         pass
 
     @abstractmethod
-    def prediction(self, prediction):
+    def prediction(self, prediction: Prediction):
         """Send latest prediction"""
         pass

--- a/tests/test_eeg_data.py
+++ b/tests/test_eeg_data.py
@@ -3,6 +3,7 @@ import unittest
 from bci_essentials.io.sources import MarkerSource, EegSource
 from bci_essentials.io.messenger import Messenger
 from bci_essentials.eeg_data import EegData
+from bci_essentials.classification.generic_classifier import Prediction
 from bci_essentials.classification.null_classifier import NullClassifier
 
 
@@ -137,5 +138,5 @@ class _MockMessenger(Messenger):
     def marker_received(self, marker):
         self.marker_received_count += 1
 
-    def prediction(self, prediction):
+    def prediction(self, prediction: Prediction):
         self.prediction_count += 1


### PR DESCRIPTION
[B4K-220](https://bci4kids.atlassian.net/browse/B4K-229)

I changed GenericClassifier.predict() to return a "Prediction" object that contains labels and associated probabilities.  I also did a small amount of cleanup in GenericClassifier to make the abstract functions actually abstract.  I cleaned up the comments for the classifiers also.

Messenger.prediction() now takes a Prediction object.  This way, a subclass of Messenger can control how the data is sent, ex: for LSL (Unity), only the labels are sent, probabilities are discarded (Unity never used them).

I made one change that might break a Unity project - in the live_update case, EegData previously sent the most recent label. 
 Now it sends a Prediction like all the other cases.  This may cause an issue where a Unity application was expecting 'label' and now it gets ['label'].  Not a big deal, but a potential gotcha.

I was able to manually test this, but a unit test would be better.  It's a bit of work though, so I'll put a task in the backlog.  I think there's a neat way to inject a fake GenericClassifier that always returns a known prediction.  Then the test can use a mock Messenger to check the prediction that's been sent.
