### PR TITLE
B4k202 -- standardize names for referring to windows, channels and samples

### DIFF
--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -3,10 +3,10 @@ This module includes functions for selecting channels in order to
 improve BCI performance.
 
 The EEG data input for each function is a set of windows. The data must
-be of the shape `W x C x S`, where:
-- W = number of windows
-- C = number of channels
-- S = number of samples
+be of the shape `num_windows x num_channels x num_samples`, where:
+- num_windows = number of windows
+- num_channels = number of channels
+- num_samples = number of samples
 
 """
 from joblib import Parallel, delayed
@@ -47,15 +47,15 @@ def channel_selection_by_method(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`W_windows`,`C_channels`,`S_samples`)
+        shape = (`num_windows`,`num_channels`,`num_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     channel_labels : list of `str`
-        The set of channel labels corresponding to `C_channels`.
-        A list of strings with length = `C_channels`.
+        The set of channel labels corresponding to `num_channels`.
+        A list of strings with length = `num_channels`.
     method = str, *optional*
         The wrapper method. Options are `"SBS"` or `"SBFS"`.
         - Default is `"SBS"`.
@@ -97,7 +97,7 @@ def channel_selection_by_method(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -206,7 +206,7 @@ def channel_selection_by_method(
 
 def __check_stopping_criterion(
     current_time,
-    nchannels,
+    num_channels,
     current_performance_delta,
     max_time,
     min_channels,
@@ -219,7 +219,7 @@ def __check_stopping_criterion(
     ----------
     current_time : float
         The time elapsed since the start of the channel selection method.
-    nchannels : int
+    num_channels : int
         The number of channels in the current iteration of the new best channel
         subset (`len(new_channel_subset)`).
     current_performance_delta : float
@@ -245,11 +245,11 @@ def __check_stopping_criterion(
         logger.debug("Stopping based on time")
         return True
 
-    elif nchannels <= min_channels:
+    elif num_channels <= min_channels:
         logger.debug("Stopping because minimum number of channels reached")
         return True
 
-    elif nchannels >= max_channels:
+    elif num_channels >= max_channels:
         logger.debug("Stopping because maximum number of channels reached")
         return True
 
@@ -287,15 +287,15 @@ def __sfs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`W_windows`,`C_channels`,`S_samples`)
+        shape = (`num_windows`,`num_channels`,`num_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     channel_labels: list of `str`
-        The set of channel labels corresponding to `C_channels`.
-        A list of strings with length = `C_channels`.
+        The set of channel labels corresponding to `num_channels`.
+        A list of strings with length = `num_channels`.
     metric : str
         The metric used to measure the "goodness" of the trained classifier.
     initial_channels : list of `str`
@@ -326,7 +326,7 @@ def __sfs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -352,7 +352,7 @@ def __sfs(
 
     start_time = time.time()
 
-    nwindows, nchannels, nsamples = X.shape
+    num_windows, num_channels, num_samples = X.shape
     sfs_subset = []
 
     for i, c in enumerate(channel_labels):
@@ -406,14 +406,14 @@ def __sfs(
     while stop_criterion is False:
         sets_to_try = []
         X_to_try = []
-        for channel in range(nchannels):
+        for channel in range(num_channels):
             if channel not in sfs_subset:
                 set_to_try = sfs_subset.copy()
                 set_to_try.append(c)
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((nwindows, len(set_to_try), nsamples))
+                new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -561,15 +561,15 @@ def __sbs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`W_windows`,`C_channels`,`S_samples`)
+        shape = (`num_windows`,`num_channels`,`num_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     channel_labels: list of `str`
-        The set of channel labels corresponding to `C_channels`.
-        A list of strings with length = `C_channels`.
+        The set of channel labels corresponding to `num_channels`.
+        A list of strings with length = `num_channels`.
     metric : str
         The metric used to measure the "goodness" of the trained classifier.
     initial_channels : list of `str`
@@ -599,7 +599,7 @@ def __sbs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -631,7 +631,7 @@ def __sbs(
 
     start_time = time.time()
 
-    nwindows, nchannels, nsamples = X.shape
+    num_windows, num_channels, num_samples = X.shape
     sbs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -689,7 +689,7 @@ def __sbs(
                 continue
 
             # Get the new subset of data
-            new_subset_data = np.zeros((nwindows, len(set_to_try), nsamples))
+            new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
             for subset_idx, channel_number in enumerate(set_to_try):
                 channel_data = X[:, channel_number, :]
                 new_subset_data[:, subset_idx, :] = channel_data
@@ -840,15 +840,15 @@ def __sbfs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`W_windows`,`C_channels`,`S_samples`)
+        shape = (`num_windows`,`num_channels`,`num_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     channel_labels: list of `str`
-        The set of channel labels corresponding to `C_channels`.
-        A list of strings with length = `C_channels`.
+        The set of channel labels corresponding to `num_channels`.
+        A list of strings with length = `num_channels`.
     metric : str
         The metric used to measure the "goodness" of the trained classifier.
     initial_channels : list of `str`
@@ -878,7 +878,7 @@ def __sbfs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -909,7 +909,7 @@ def __sbfs(
 
     start_time = time.time()
 
-    nwindows, nchannels, nsamples = X.shape
+    num_windows, num_channels, num_samples = X.shape
     sbfs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -984,7 +984,7 @@ def __sbfs(
                 continue
 
             # Get the new subset of data
-            new_subset_data = np.zeros((nwindows, len(set_to_try), nsamples))
+            new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
             for subset_idx, channel_number in enumerate(set_to_try):
                 channel_data = X[:, channel_number, :]
                 new_subset_data[:, subset_idx, :] = channel_data
@@ -1042,7 +1042,7 @@ def __sbfs(
 
         current_performance = best_round_performance
 
-        # If this is the best perfomance at nchannels
+        # If this is the best perfomance at num_channels
         if performance_at_nchannels[len(sbfs_subset) - 1] < current_performance:
             performance_at_nchannels[len(sbfs_subset) - 1] = current_performance
             best_subset_at_nchannels[len(sbfs_subset) - 1] = sbfs_subset
@@ -1115,7 +1115,7 @@ def __sbfs(
                     continue
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((nwindows, len(set_to_try), nsamples))
+                new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -1160,7 +1160,7 @@ def __sbfs(
             best_round_performance = np.max(performances)
             best_set_index = accuracies.index(best_round_performance)
 
-            # if performance is better the best performance at nchannels
+            # if performance is better the best performance at num_channels
             if (
                 performance_at_nchannels[length_of_resultant_set - 1]
                 < best_round_performance
@@ -1294,15 +1294,15 @@ def __sffs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`W_windows`,`C_channels`,`S_samples`)
+        shape = (`num_windows`,`num_channels`,`num_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     channel_labels: list of `str`
-        The set of channel labels corresponding to `C_channels`.
-        A list of strings with length = `C_channels`.
+        The set of channel labels corresponding to `num_channels`.
+        A list of strings with length = `num_channels`.
     metric : str
         The metric used to measure the "goodness" of the trained classifier.
     initial_channels : list of `str`
@@ -1332,7 +1332,7 @@ def __sffs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`nwindows`)
+        shape = (`num_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -1360,7 +1360,7 @@ def __sffs(
 
     start_time = time.time()
 
-    nwindows, nchannels, nsamples = X.shape
+    num_windows, num_channels, num_samples = X.shape
     sffs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -1426,14 +1426,14 @@ def __sffs(
     while stop_criterion is False:
         sets_to_try = []
         X_to_try = []
-        for c in range(nchannels):
+        for c in range(num_channels):
             if c not in sffs_subset:
                 set_to_try = sffs_subset.copy()
                 set_to_try.append(c)
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((nwindows, len(set_to_try), nsamples))
+                new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -1489,7 +1489,7 @@ def __sffs(
         logger.debug("Accuracy: %s", accuracy)
         logger.debug("Accuracies: %s", accuracies)
 
-        # If this is the best perfomance at nchannels
+        # If this is the best perfomance at num_channels
         if performance_at_nchannels[len(sffs_subset) - 1] < current_performance:
             performance_at_nchannels[len(sffs_subset) - 1] = current_performance
             best_subset_at_nchannels[len(sffs_subset) - 1] = sffs_subset
@@ -1562,7 +1562,7 @@ def __sffs(
                     continue
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((nwindows, len(set_to_try), nsamples))
+                new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -3,10 +3,10 @@ This module includes functions for selecting channels in order to
 improve BCI performance.
 
 The EEG data input for each function is a set of windows. The data must
-be of the shape `num_windows x num_channels x num_samples`, where:
+be of the shape `num_windows x n_channels x n_samples`, where:
 - num_windows = number of windows
-- num_channels = number of channels
-- num_samples = number of samples
+- n_channels = number of channels
+- n_samples = number of samples
 
 """
 from joblib import Parallel, delayed
@@ -47,15 +47,15 @@ def channel_selection_by_method(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`num_channels`,`num_samples`)
+        shape = (`num_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
         shape = (`num_windows`)
     channel_labels : list of `str`
-        The set of channel labels corresponding to `num_channels`.
-        A list of strings with length = `num_channels`.
+        The set of channel labels corresponding to `n_channels`.
+        A list of strings with length = `n_channels`.
     method = str, *optional*
         The wrapper method. Options are `"SBS"` or `"SBFS"`.
         - Default is `"SBS"`.
@@ -206,7 +206,7 @@ def channel_selection_by_method(
 
 def __check_stopping_criterion(
     current_time,
-    num_channels,
+    n_channels,
     current_performance_delta,
     max_time,
     min_channels,
@@ -219,7 +219,7 @@ def __check_stopping_criterion(
     ----------
     current_time : float
         The time elapsed since the start of the channel selection method.
-    num_channels : int
+    n_channels : int
         The number of channels in the current iteration of the new best channel
         subset (`len(new_channel_subset)`).
     current_performance_delta : float
@@ -245,11 +245,11 @@ def __check_stopping_criterion(
         logger.debug("Stopping based on time")
         return True
 
-    elif num_channels <= min_channels:
+    elif n_channels <= min_channels:
         logger.debug("Stopping because minimum number of channels reached")
         return True
 
-    elif num_channels >= max_channels:
+    elif n_channels >= max_channels:
         logger.debug("Stopping because maximum number of channels reached")
         return True
 
@@ -287,15 +287,15 @@ def __sfs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`num_channels`,`num_samples`)
+        shape = (`num_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
         shape = (`num_windows`)
     channel_labels: list of `str`
-        The set of channel labels corresponding to `num_channels`.
-        A list of strings with length = `num_channels`.
+        The set of channel labels corresponding to `n_channels`.
+        A list of strings with length = `n_channels`.
     metric : str
         The metric used to measure the "goodness" of the trained classifier.
     initial_channels : list of `str`
@@ -352,7 +352,7 @@ def __sfs(
 
     start_time = time.time()
 
-    num_windows, num_channels, num_samples = X.shape
+    num_windows, n_channels, n_samples = X.shape
     sfs_subset = []
 
     for i, c in enumerate(channel_labels):
@@ -406,14 +406,14 @@ def __sfs(
     while stop_criterion is False:
         sets_to_try = []
         X_to_try = []
-        for channel in range(num_channels):
+        for channel in range(n_channels):
             if channel not in sfs_subset:
                 set_to_try = sfs_subset.copy()
                 set_to_try.append(c)
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
+                new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -561,15 +561,15 @@ def __sbs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`num_channels`,`num_samples`)
+        shape = (`num_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
         shape = (`num_windows`)
     channel_labels: list of `str`
-        The set of channel labels corresponding to `num_channels`.
-        A list of strings with length = `num_channels`.
+        The set of channel labels corresponding to `n_channels`.
+        A list of strings with length = `n_channels`.
     metric : str
         The metric used to measure the "goodness" of the trained classifier.
     initial_channels : list of `str`
@@ -631,7 +631,7 @@ def __sbs(
 
     start_time = time.time()
 
-    num_windows, num_channels, num_samples = X.shape
+    num_windows, n_channels, n_samples = X.shape
     sbs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -689,7 +689,7 @@ def __sbs(
                 continue
 
             # Get the new subset of data
-            new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
+            new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
             for subset_idx, channel_number in enumerate(set_to_try):
                 channel_data = X[:, channel_number, :]
                 new_subset_data[:, subset_idx, :] = channel_data
@@ -840,15 +840,15 @@ def __sbfs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`num_channels`,`num_samples`)
+        shape = (`num_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
         shape = (`num_windows`)
     channel_labels: list of `str`
-        The set of channel labels corresponding to `num_channels`.
-        A list of strings with length = `num_channels`.
+        The set of channel labels corresponding to `n_channels`.
+        A list of strings with length = `n_channels`.
     metric : str
         The metric used to measure the "goodness" of the trained classifier.
     initial_channels : list of `str`
@@ -909,7 +909,7 @@ def __sbfs(
 
     start_time = time.time()
 
-    num_windows, num_channels, num_samples = X.shape
+    num_windows, n_channels, n_samples = X.shape
     sbfs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -984,7 +984,7 @@ def __sbfs(
                 continue
 
             # Get the new subset of data
-            new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
+            new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
             for subset_idx, channel_number in enumerate(set_to_try):
                 channel_data = X[:, channel_number, :]
                 new_subset_data[:, subset_idx, :] = channel_data
@@ -1042,7 +1042,7 @@ def __sbfs(
 
         current_performance = best_round_performance
 
-        # If this is the best perfomance at num_channels
+        # If this is the best perfomance at n_channels
         if performance_at_nchannels[len(sbfs_subset) - 1] < current_performance:
             performance_at_nchannels[len(sbfs_subset) - 1] = current_performance
             best_subset_at_nchannels[len(sbfs_subset) - 1] = sbfs_subset
@@ -1115,7 +1115,7 @@ def __sbfs(
                     continue
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
+                new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -1160,7 +1160,7 @@ def __sbfs(
             best_round_performance = np.max(performances)
             best_set_index = accuracies.index(best_round_performance)
 
-            # if performance is better the best performance at num_channels
+            # if performance is better the best performance at n_channels
             if (
                 performance_at_nchannels[length_of_resultant_set - 1]
                 < best_round_performance
@@ -1294,15 +1294,15 @@ def __sffs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`num_channels`,`num_samples`)
+        shape = (`num_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
         shape = (`num_windows`)
     channel_labels: list of `str`
-        The set of channel labels corresponding to `num_channels`.
-        A list of strings with length = `num_channels`.
+        The set of channel labels corresponding to `n_channels`.
+        A list of strings with length = `n_channels`.
     metric : str
         The metric used to measure the "goodness" of the trained classifier.
     initial_channels : list of `str`
@@ -1360,7 +1360,7 @@ def __sffs(
 
     start_time = time.time()
 
-    num_windows, num_channels, num_samples = X.shape
+    num_windows, n_channels, n_samples = X.shape
     sffs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -1426,14 +1426,14 @@ def __sffs(
     while stop_criterion is False:
         sets_to_try = []
         X_to_try = []
-        for c in range(num_channels):
+        for c in range(n_channels):
             if c not in sffs_subset:
                 set_to_try = sffs_subset.copy()
                 set_to_try.append(c)
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
+                new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -1489,7 +1489,7 @@ def __sffs(
         logger.debug("Accuracy: %s", accuracy)
         logger.debug("Accuracies: %s", accuracies)
 
-        # If this is the best perfomance at num_channels
+        # If this is the best perfomance at n_channels
         if performance_at_nchannels[len(sffs_subset) - 1] < current_performance:
             performance_at_nchannels[len(sffs_subset) - 1] = current_performance
             best_subset_at_nchannels[len(sffs_subset) - 1] = sffs_subset
@@ -1562,7 +1562,7 @@ def __sffs(
                     continue
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((num_windows, len(set_to_try), num_samples))
+                new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -3,8 +3,8 @@ This module includes functions for selecting channels in order to
 improve BCI performance.
 
 The EEG data input for each function is a set of windows. The data must
-be of the shape `num_windows x n_channels x n_samples`, where:
-- num_windows = number of windows
+be of the shape `n_windows x n_channels x n_samples`, where:
+- n_windows = number of windows
 - n_channels = number of channels
 - n_samples = number of samples
 
@@ -47,12 +47,12 @@ def channel_selection_by_method(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`n_channels`,`n_samples`)
+        shape = (`n_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     channel_labels : list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -97,7 +97,7 @@ def channel_selection_by_method(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -287,12 +287,12 @@ def __sfs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`n_channels`,`n_samples`)
+        shape = (`n_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     channel_labels: list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -326,7 +326,7 @@ def __sfs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -352,7 +352,7 @@ def __sfs(
 
     start_time = time.time()
 
-    num_windows, n_channels, n_samples = X.shape
+    n_windows, n_channels, n_samples = X.shape
     sfs_subset = []
 
     for i, c in enumerate(channel_labels):
@@ -413,7 +413,7 @@ def __sfs(
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
+                new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -561,12 +561,12 @@ def __sbs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`n_channels`,`n_samples`)
+        shape = (`n_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     channel_labels: list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -599,7 +599,7 @@ def __sbs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -631,7 +631,7 @@ def __sbs(
 
     start_time = time.time()
 
-    num_windows, n_channels, n_samples = X.shape
+    n_windows, n_channels, n_samples = X.shape
     sbs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -689,7 +689,7 @@ def __sbs(
                 continue
 
             # Get the new subset of data
-            new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
+            new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
             for subset_idx, channel_number in enumerate(set_to_try):
                 channel_data = X[:, channel_number, :]
                 new_subset_data[:, subset_idx, :] = channel_data
@@ -840,12 +840,12 @@ def __sbfs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`n_channels`,`n_samples`)
+        shape = (`n_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     channel_labels: list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -878,7 +878,7 @@ def __sbfs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -909,7 +909,7 @@ def __sbfs(
 
     start_time = time.time()
 
-    num_windows, n_channels, n_samples = X.shape
+    n_windows, n_channels, n_samples = X.shape
     sbfs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -984,7 +984,7 @@ def __sbfs(
                 continue
 
             # Get the new subset of data
-            new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
+            new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
             for subset_idx, channel_number in enumerate(set_to_try):
                 channel_data = X[:, channel_number, :]
                 new_subset_data[:, subset_idx, :] = channel_data
@@ -1115,7 +1115,7 @@ def __sbfs(
                     continue
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
+                new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -1294,12 +1294,12 @@ def __sffs(
         Training data for the classifier as windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`n_channels`,`n_samples`)
+        shape = (`n_windows`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     channel_labels: list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -1332,7 +1332,7 @@ def __sffs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`num_windows`)
+        shape = (`n_windows`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -1360,7 +1360,7 @@ def __sffs(
 
     start_time = time.time()
 
-    num_windows, n_channels, n_samples = X.shape
+    n_windows, n_channels, n_samples = X.shape
     sffs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -1433,7 +1433,7 @@ def __sffs(
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
+                new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -1562,7 +1562,7 @@ def __sffs(
                     continue
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((num_windows, len(set_to_try), n_samples))
+                new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -2,9 +2,9 @@
 This module includes functions for selecting channels in order to
 improve BCI performance.
 
-The EEG data input for each function is a set of windows. The data must
-be of the shape `n_windows x n_channels x n_samples`, where:
-- n_windows = number of windows
+The EEG data input for each function is a set of trials. The data must
+be of the shape `n_trials x n_channels x n_samples`, where:
+- n_trials = number of trials
 - n_channels = number of channels
 - n_samples = number of samples
 
@@ -44,15 +44,15 @@ def channel_selection_by_method(
         and classification.
         Different functions  are used for MI, P300, SSVEP, etc.
     X : numpy.ndarray
-        Training data for the classifier as windows of EEG data.
+        Training data for the classifier as trials of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`n_windows`,`n_channels`,`n_samples`)
+        shape = (`n_trials`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     channel_labels : list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -97,7 +97,7 @@ def channel_selection_by_method(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -284,15 +284,15 @@ def __sfs(
         and classification.
         Different functions  are used for MI, P300, SSVEP, etc.
     X : numpy.ndarray
-        Training data for the classifier as windows of EEG data.
+        Training data for the classifier as trials of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`n_windows`,`n_channels`,`n_samples`)
+        shape = (`n_trials`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     channel_labels: list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -326,7 +326,7 @@ def __sfs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -352,7 +352,7 @@ def __sfs(
 
     start_time = time.time()
 
-    n_windows, n_channels, n_samples = X.shape
+    n_trials, n_channels, n_samples = X.shape
     sfs_subset = []
 
     for i, c in enumerate(channel_labels):
@@ -413,7 +413,7 @@ def __sfs(
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
+                new_subset_data = np.zeros((n_trials, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -558,15 +558,15 @@ def __sbs(
         and classification.
         Different functions  are used for MI, P300, SSVEP, etc.
     X : numpy.ndarray
-        Training data for the classifier as windows of EEG data.
+        Training data for the classifier as trials of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`n_windows`,`n_channels`,`n_samples`)
+        shape = (`n_trials`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     channel_labels: list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -599,7 +599,7 @@ def __sbs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -631,7 +631,7 @@ def __sbs(
 
     start_time = time.time()
 
-    n_windows, n_channels, n_samples = X.shape
+    n_trials, n_channels, n_samples = X.shape
     sbs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -689,7 +689,7 @@ def __sbs(
                 continue
 
             # Get the new subset of data
-            new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
+            new_subset_data = np.zeros((n_trials, len(set_to_try), n_samples))
             for subset_idx, channel_number in enumerate(set_to_try):
                 channel_data = X[:, channel_number, :]
                 new_subset_data[:, subset_idx, :] = channel_data
@@ -837,15 +837,15 @@ def __sbfs(
         and classification.
         Different functions  are used for MI, P300, SSVEP, etc.
     X : numpy.ndarray
-        Training data for the classifier as windows of EEG data.
+        Training data for the classifier as trials of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`n_windows`,`n_channels`,`n_samples`)
+        shape = (`n_trials`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     channel_labels: list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -878,7 +878,7 @@ def __sbfs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -909,7 +909,7 @@ def __sbfs(
 
     start_time = time.time()
 
-    n_windows, n_channels, n_samples = X.shape
+    n_trials, n_channels, n_samples = X.shape
     sbfs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -984,7 +984,7 @@ def __sbfs(
                 continue
 
             # Get the new subset of data
-            new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
+            new_subset_data = np.zeros((n_trials, len(set_to_try), n_samples))
             for subset_idx, channel_number in enumerate(set_to_try):
                 channel_data = X[:, channel_number, :]
                 new_subset_data[:, subset_idx, :] = channel_data
@@ -1115,7 +1115,7 @@ def __sbfs(
                     continue
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
+                new_subset_data = np.zeros((n_trials, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -1291,15 +1291,15 @@ def __sffs(
         and classification.
         Different functions  are used for MI, P300, SSVEP, etc.
     X : numpy.ndarray
-        Training data for the classifier as windows of EEG data.
+        Training data for the classifier as trials of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`n_windows`,`n_channels`,`n_samples`)
+        shape = (`n_trials`,`n_channels`,`n_samples`)
     y : numpy.ndarray
         Training labels for the classifier.
         1D array.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     channel_labels: list of `str`
         The set of channel labels corresponding to `n_channels`.
         A list of strings with length = `n_channels`.
@@ -1332,7 +1332,7 @@ def __sffs(
         The predictions from the model.
         1D array with the same shape as `y`.
 
-        shape = (`n_windows`)
+        shape = (`n_trials`)
     accuracy : float
         The accuracy of the trained classification model.
     precision : float
@@ -1360,7 +1360,7 @@ def __sffs(
 
     start_time = time.time()
 
-    n_windows, n_channels, n_samples = X.shape
+    n_trials, n_channels, n_samples = X.shape
     sffs_subset = []
     all_sets_tried = []  # set of all channels that have been tried
 
@@ -1433,7 +1433,7 @@ def __sffs(
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
+                new_subset_data = np.zeros((n_trials, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data
@@ -1562,7 +1562,7 @@ def __sffs(
                     continue
 
                 # Get the new subset of data
-                new_subset_data = np.zeros((n_windows, len(set_to_try), n_samples))
+                new_subset_data = np.zeros((n_trials, len(set_to_try), n_samples))
                 for subset_idx, channel_number in enumerate(set_to_try):
                     channel_data = X[:, channel_number, :]
                     new_subset_data[:, subset_idx, :] = channel_data

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -93,7 +93,7 @@ class ErpRgClassifier(GenericClassifier):
             If array, state size and type. E.g.
             3D array containing data with `float` type.
 
-            shape = (`1st_dimension`,`2nd_dimension`,`3rd_dimension`)
+            shape = (`num_decisions`,`num_channels`,`num_samples`)
         label_idx : type
             Description of parameter `label_idx`.
 
@@ -103,16 +103,16 @@ class ErpRgClassifier(GenericClassifier):
 
         """
         logger.debug("Adding to training set")
-        # n = number of channels
-        # m = number of samples
-        # p = number of epochs
-        p, n, m = decision_block.shape
+        # num_decisions = number of epochs/decisions
+        # num_channels = number of channels
+        # num_samples = number of samples
+        num_decisions, num_channels, num_samples = decision_block.shape
 
         # get a subset
         decision_block = self.get_subset(decision_block)
 
         # get labels from label_idx
-        labels = np.zeros([p])
+        labels = np.zeros([num_decisions])
         labels[label_idx] = 1
         logger.debug("Labels: %s", labels)
 
@@ -390,7 +390,7 @@ class ErpRgClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (windows, channels, samples)
+            3D array where shape = (num_windows, num_channels, num_samples)
 
         Returns
         -------

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -93,7 +93,7 @@ class ErpRgClassifier(GenericClassifier):
             If array, state size and type. E.g.
             3D array containing data with `float` type.
 
-            shape = (`num_decisions`,`num_channels`,`num_samples`)
+            shape = (`num_decisions`,`n_channels`,`n_samples`)
         label_idx : type
             Description of parameter `label_idx`.
 
@@ -104,9 +104,9 @@ class ErpRgClassifier(GenericClassifier):
         """
         logger.debug("Adding to training set")
         # num_decisions = number of epochs/decisions
-        # num_channels = number of channels
-        # num_samples = number of samples
-        num_decisions, num_channels, num_samples = decision_block.shape
+        # n_channels = number of channels
+        # n_samples = number of samples
+        num_decisions, n_channels, n_samples = decision_block.shape
 
         # get a subset
         decision_block = self.get_subset(decision_block)
@@ -390,7 +390,7 @@ class ErpRgClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (num_windows, num_channels, num_samples)
+            3D array where shape = (num_windows, n_channels, n_samples)
 
         Returns
         -------

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -93,7 +93,7 @@ class ErpRgClassifier(GenericClassifier):
             If array, state size and type. E.g.
             3D array containing data with `float` type.
 
-            shape = (`num_decisions`,`n_channels`,`n_samples`)
+            shape = (`n_decisions`,`n_channels`,`n_samples`)
         label_idx : type
             Description of parameter `label_idx`.
 
@@ -103,16 +103,16 @@ class ErpRgClassifier(GenericClassifier):
 
         """
         logger.debug("Adding to training set")
-        # num_decisions = number of epochs/decisions
+        # n_decisions = number of epochs/decisions
         # n_channels = number of channels
         # n_samples = number of samples
-        num_decisions, n_channels, n_samples = decision_block.shape
+        n_decisions, n_channels, n_samples = decision_block.shape
 
         # get a subset
         decision_block = self.get_subset(decision_block)
 
         # get labels from label_idx
-        labels = np.zeros([num_decisions])
+        labels = np.zeros([n_decisions])
         labels[label_idx] = 1
         logger.debug("Labels: %s", labels)
 

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -390,7 +390,7 @@ class ErpRgClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (num_windows, n_channels, n_samples)
+            3D array where shape = (n_windows, n_channels, n_samples)
 
         Returns
         -------

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -390,7 +390,7 @@ class ErpRgClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (n_windows, n_channels, n_samples)
+            3D array where shape = (n_trials, n_channels, n_samples)
 
         Returns
         -------

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -88,14 +88,14 @@ class GenericClassifier(ABC):
         offline_recall : list of `float`
             Description of attribute `offline_recall`.
             - Initial value is `[]`.
-        offline_window_count : int
-            Description of attribute `offline_window_count`.
+        offline_trial_count : int
+            Description of attribute `offline_trial_count`.
             - Initial value is `0`.
-        offline_window_counts : list of `int`
-            Description of attribute `offline_window_counts`.
+        offline_trial_counts : list of `int`
+            Description of attribute `offline_trial_counts`.
             - Initial value is `[]`.
-        next_fit_window : int
-            Description of attribute `next_fit_window`.
+        next_fit_trial : int
+            Description of attribute `next_fit_trial`.
             - Initial value is `0`.
         predictions : list of `type`
             Description of attribute `predictions`.
@@ -128,13 +128,13 @@ class GenericClassifier(ABC):
         """@private (This is just for the API docs, to avoid double listing."""
         self.offline_recall = []
         """@private (This is just for the API docs, to avoid double listing."""
-        self.offline_window_count = 0
+        self.offline_trial_count = 0
         """@private (This is just for the API docs, to avoid double listing."""
-        self.offline_window_counts = []
+        self.offline_trial_counts = []
         """@private (This is just for the API docs, to avoid double listing."""
 
         # For iterative fitting,
-        self.next_fit_window = 0
+        self.next_fit_trial = 0
         """@private (This is just for the API docs, to avoid double listing."""
 
         # Keep track of predictions
@@ -151,7 +151,7 @@ class GenericClassifier(ABC):
         X : numpy.ndarray, *optional*
             3D array containing data with `float` type.
 
-            shape = (`N_windows`,`M_channels`,`P_samples`)
+            shape = (`N_trials`,`M_channels`,`P_samples`)
             - Default is `[]`.
         subset : list of `int` or `str`, *optional*
             List of indices (int) or labels (str) of the desired channels.
@@ -166,7 +166,7 @@ class GenericClassifier(ABC):
             Subset of input `X` according to labels or indices.
             3D array containing data with `float` type.
 
-            shape = (`N_windows`,`M_channels`,`P_samples`)
+            shape = (`N_trials`,`M_channels`,`P_samples`)
 
         """
 
@@ -196,7 +196,7 @@ class GenericClassifier(ABC):
 
             # Return for the given indices
             try:
-                # n_windows, n_channels, n_samples = self.X.shape
+                # n_trials, n_channels, n_samples = self.X.shape
 
                 if sum(X.shape) == 0:
                     new_X = self.X[:, subset_indices, :]
@@ -393,7 +393,7 @@ class GenericClassifier(ABC):
         """Abstract method to predict with classifier
 
         X : numpy.ndarray
-            3D array where shape = (windows, channels, samples)
+            3D array where shape = (trials, channels, samples)
 
         Returns
         -------

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -151,7 +151,7 @@ class GenericClassifier(ABC):
         X : numpy.ndarray, *optional*
             3D array containing data with `float` type.
 
-            shape = (`N_trials`,`M_channels`,`P_samples`)
+            shape = (`n_trials`,`n_channels`,`n_samples`)
             - Default is `[]`.
         subset : list of `int` or `str`, *optional*
             List of indices (int) or labels (str) of the desired channels.
@@ -166,7 +166,7 @@ class GenericClassifier(ABC):
             Subset of input `X` according to labels or indices.
             3D array containing data with `float` type.
 
-            shape = (`N_trials`,`M_channels`,`P_samples`)
+            shape = (`n_trials`,`n_channels`,`n_samples`)
 
         """
 

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -196,7 +196,7 @@ class GenericClassifier(ABC):
 
             # Return for the given indices
             try:
-                # nwindows, nchannels, nsamples = self.X.shape
+                # num_windows, num_channels, num_samples = self.X.shape
 
                 if sum(X.shape) == 0:
                     new_X = self.X[:, subset_indices, :]
@@ -207,7 +207,7 @@ class GenericClassifier(ABC):
                     return X
 
             except Exception:
-                # nchannels, nsamples = self.X.shape
+                # num_channels, num_samples = self.X.shape
                 if sum(X.shape) == 0:
                     new_X = self.X[subset_indices, :]
                     self.X = new_X

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -196,7 +196,7 @@ class GenericClassifier(ABC):
 
             # Return for the given indices
             try:
-                # num_windows, num_channels, num_samples = self.X.shape
+                # num_windows, n_channels, n_samples = self.X.shape
 
                 if sum(X.shape) == 0:
                     new_X = self.X[:, subset_indices, :]
@@ -207,7 +207,7 @@ class GenericClassifier(ABC):
                     return X
 
             except Exception:
-                # num_channels, num_samples = self.X.shape
+                # n_channels, n_samples = self.X.shape
                 if sum(X.shape) == 0:
                     new_X = self.X[subset_indices, :]
                     self.X = new_X

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -196,7 +196,7 @@ class GenericClassifier(ABC):
 
             # Return for the given indices
             try:
-                # num_windows, n_channels, n_samples = self.X.shape
+                # n_windows, n_channels, n_samples = self.X.shape
 
                 if sum(X.shape) == 0:
                     new_X = self.X[:, subset_indices, :]

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -158,23 +158,23 @@ class MiClassifier(GenericClassifier):
 
         """
         # get dimensions
-        n_windows, n_channels, n_samples = self.X.shape
+        n_trials, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         self.X = np.array(self.X)
 
         # Try rebuilding the classifier each time
         if self.rebuild:
-            self.next_fit_window = 0
+            self.next_fit_trial = 0
             self.clf = self.clf_model
 
         # get temporal subset
-        subX = self.X[self.next_fit_window :, :, :]
-        suby = self.y[self.next_fit_window :]
-        self.next_fit_window = n_windows
+        subX = self.X[self.next_fit_trial :, :, :]
+        suby = self.y[self.next_fit_trial :]
+        self.next_fit_trial = n_trials
 
         # Init predictions to all false
-        preds = np.zeros(n_windows)
+        preds = np.zeros(n_trials)
 
         def __mi_kernel(subX, suby):
             """MI kernel.
@@ -279,8 +279,8 @@ class MiClassifier(GenericClassifier):
 
         # Log performance stats
 
-        self.offline_window_count = n_windows
-        self.offline_window_counts.append(self.offline_window_count)
+        self.offline_trial_count = n_trials
+        self.offline_trial_counts.append(self.offline_trial_count)
 
         # accuracy
         accuracy = sum(preds == self.y) / len(preds)
@@ -308,7 +308,7 @@ class MiClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (windows, channels, samples)
+            3D array where shape = (trials, channels, samples)
 
         Returns
         -------

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -158,7 +158,7 @@ class MiClassifier(GenericClassifier):
 
         """
         # get dimensions
-        num_windows, num_channels, num_samples = self.X.shape
+        num_windows, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         self.X = np.array(self.X)

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -158,7 +158,7 @@ class MiClassifier(GenericClassifier):
 
         """
         # get dimensions
-        num_windows, n_channels, n_samples = self.X.shape
+        n_windows, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         self.X = np.array(self.X)
@@ -171,10 +171,10 @@ class MiClassifier(GenericClassifier):
         # get temporal subset
         subX = self.X[self.next_fit_window :, :, :]
         suby = self.y[self.next_fit_window :]
-        self.next_fit_window = num_windows
+        self.next_fit_window = n_windows
 
         # Init predictions to all false
-        preds = np.zeros(num_windows)
+        preds = np.zeros(n_windows)
 
         def __mi_kernel(subX, suby):
             """MI kernel.
@@ -279,7 +279,7 @@ class MiClassifier(GenericClassifier):
 
         # Log performance stats
 
-        self.offline_window_count = num_windows
+        self.offline_window_count = n_windows
         self.offline_window_counts.append(self.offline_window_count)
 
         # accuracy

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -158,7 +158,7 @@ class MiClassifier(GenericClassifier):
 
         """
         # get dimensions
-        nwindows, nchannels, nsamples = self.X.shape
+        num_windows, num_channels, num_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         self.X = np.array(self.X)
@@ -171,10 +171,10 @@ class MiClassifier(GenericClassifier):
         # get temporal subset
         subX = self.X[self.next_fit_window :, :, :]
         suby = self.y[self.next_fit_window :]
-        self.next_fit_window = nwindows
+        self.next_fit_window = num_windows
 
         # Init predictions to all false
-        preds = np.zeros(nwindows)
+        preds = np.zeros(num_windows)
 
         def __mi_kernel(subX, suby):
             """MI kernel.
@@ -279,7 +279,7 @@ class MiClassifier(GenericClassifier):
 
         # Log performance stats
 
-        self.offline_window_count = nwindows
+        self.offline_window_count = num_windows
         self.offline_window_counts.append(self.offline_window_count)
 
         # accuracy

--- a/bci_essentials/classification/null_classifier.py
+++ b/bci_essentials/classification/null_classifier.py
@@ -36,7 +36,7 @@ class NullClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (windows, channels, samples)
+            3D array where shape = (trials, channels, samples)
 
 
         Returns

--- a/bci_essentials/classification/ssvep_basic_tf_classifier.py
+++ b/bci_essentials/classification/ssvep_basic_tf_classifier.py
@@ -64,7 +64,7 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (windows, channels, samples)
+            3D array where shape = (trials, channels, samples)
 
         Returns
         -------
@@ -74,7 +74,7 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
 
         """
         # get the shape
-        n_windows, n_channels, n_samples = X.shape
+        n_trials, n_channels, n_samples = X.shape
         # The first time it is called it must be set up
         if self.setup is False:
             logger.info("Setting up the training free classifier")
@@ -87,17 +87,17 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
         # Get the PSD estimate using Welch's method
         f, Pxx = signal.welch(augmented_X, fs=self.sampling_freq, nperseg=n_samples)
 
-        # Get a vote for each window
-        prediction = np.zeros(n_windows)
-        for window in range(n_windows):
+        # Get a vote for each trial
+        prediction = np.zeros(n_trials)
+        for trial in range(n_trials):
             # Get the frequency with the greatest PSD
             Pxx_of_f_bins = np.zeros(len(self.target_freqs))
             for i, tf in enumerate(self.target_freqs):
                 # Get the closest frequency bin
                 closest_freq_bin = np.argmin(np.abs(f - tf))
 
-                Pxx_of_f_bins[i] = Pxx[window][int(closest_freq_bin)]
+                Pxx_of_f_bins[i] = Pxx[trial][int(closest_freq_bin)]
 
-            prediction[window] = np.argmax(Pxx_of_f_bins)
+            prediction[trial] = np.argmax(Pxx_of_f_bins)
 
         return Prediction(labels=prediction)

--- a/bci_essentials/classification/ssvep_basic_tf_classifier.py
+++ b/bci_essentials/classification/ssvep_basic_tf_classifier.py
@@ -74,7 +74,7 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
 
         """
         # get the shape
-        nwindows, nchannels, nsamples = X.shape
+        num_windows, num_channels, num_samples = X.shape
         # The first time it is called it must be set up
         if self.setup is False:
             logger.info("Setting up the training free classifier")
@@ -85,19 +85,19 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
         augmented_X = np.mean(X, axis=1)
 
         # Get the PSD estimate using Welch's method
-        f, Pxx = signal.welch(augmented_X, fs=self.sampling_freq, nperseg=nsamples)
+        f, Pxx = signal.welch(augmented_X, fs=self.sampling_freq, nperseg=num_samples)
 
         # Get a vote for each window
-        prediction = np.zeros(nwindows)
-        for w in range(nwindows):
+        prediction = np.zeros(num_windows)
+        for window in range(num_windows):
             # Get the frequency with the greatest PSD
             Pxx_of_f_bins = np.zeros(len(self.target_freqs))
             for i, tf in enumerate(self.target_freqs):
                 # Get the closest frequency bin
                 closest_freq_bin = np.argmin(np.abs(f - tf))
 
-                Pxx_of_f_bins[i] = Pxx[w][int(closest_freq_bin)]
+                Pxx_of_f_bins[i] = Pxx[window][int(closest_freq_bin)]
 
-            prediction[w] = np.argmax(Pxx_of_f_bins)
+            prediction[window] = np.argmax(Pxx_of_f_bins)
 
         return Prediction(labels=prediction)

--- a/bci_essentials/classification/ssvep_basic_tf_classifier.py
+++ b/bci_essentials/classification/ssvep_basic_tf_classifier.py
@@ -74,7 +74,7 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
 
         """
         # get the shape
-        num_windows, num_channels, num_samples = X.shape
+        num_windows, n_channels, n_samples = X.shape
         # The first time it is called it must be set up
         if self.setup is False:
             logger.info("Setting up the training free classifier")
@@ -85,7 +85,7 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
         augmented_X = np.mean(X, axis=1)
 
         # Get the PSD estimate using Welch's method
-        f, Pxx = signal.welch(augmented_X, fs=self.sampling_freq, nperseg=num_samples)
+        f, Pxx = signal.welch(augmented_X, fs=self.sampling_freq, nperseg=n_samples)
 
         # Get a vote for each window
         prediction = np.zeros(num_windows)

--- a/bci_essentials/classification/ssvep_basic_tf_classifier.py
+++ b/bci_essentials/classification/ssvep_basic_tf_classifier.py
@@ -74,7 +74,7 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
 
         """
         # get the shape
-        num_windows, n_channels, n_samples = X.shape
+        n_windows, n_channels, n_samples = X.shape
         # The first time it is called it must be set up
         if self.setup is False:
             logger.info("Setting up the training free classifier")
@@ -88,8 +88,8 @@ class SsvepBasicTrainFreeClassifier(GenericClassifier):
         f, Pxx = signal.welch(augmented_X, fs=self.sampling_freq, nperseg=n_samples)
 
         # Get a vote for each window
-        prediction = np.zeros(num_windows)
-        for window in range(num_windows):
+        prediction = np.zeros(n_windows)
+        for window in range(n_windows):
             # Get the frequency with the greatest PSD
             Pxx_of_f_bins = np.zeros(len(self.target_freqs))
             for i, tf in enumerate(self.target_freqs):

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -102,7 +102,7 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
             Windows of EEG data.
             3D array containing data with `float` type.
 
-            shape = (`num_windows`,`num_channels`,`num_samples`)
+            shape = (`num_windows`,`n_channels`,`n_samples`)
         target_freqs : numpy.ndarray
             Target frequencies for the SSVEP.
         fsample : float
@@ -124,22 +124,22 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
             Supertrials of X.
             3D array containing data with `float` type.
 
-            shape = (`num_windows`,`num_channels*number of target_freqs`,
-            `num_channels*number of target_freqs`)
+            shape = (`num_windows`,`n_channels*number of target_freqs`,
+            `n_channels*number of target_freqs`)
 
         """
-        num_windows, num_channels, num_samples = X.shape
+        num_windows, n_channels, n_samples = X.shape
         n_target_freqs = len(target_freqs)
 
         super_X = np.zeros(
-            [num_windows, num_channels * n_target_freqs, num_channels * n_target_freqs]
+            [num_windows, n_channels * n_target_freqs, n_channels * n_target_freqs]
         )
 
         # Create super trial of all trials filtered at all bands
         for window in range(num_windows):
             for tf, target_freq in enumerate(target_freqs):
-                lower_bound = int((num_channels * tf))
-                upper_bound = int((num_channels * tf) + num_channels)
+                lower_bound = int((n_channels * tf))
+                upper_bound = int((n_channels * tf) + n_channels)
 
                 signal = X[window, :, :]
                 for f in range(n_harmonics):
@@ -184,8 +184,8 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
         # get dimensions
         # X = self.X
 
-        # Convert each window of X into a SPD of dimensions [num_windows, num_channels*nfreqs, num_channels*nfreqs]
-        num_windows, num_channels, num_samples = self.X.shape
+        # Convert each window of X into a SPD of dimensions [num_windows, n_channels*nfreqs, n_channels*nfreqs]
+        num_windows, n_channels, n_samples = self.X.shape
 
         #################
         # Try rebuilding the classifier each time

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -102,7 +102,7 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
             Windows of EEG data.
             3D array containing data with `float` type.
 
-            shape = (`num_windows`,`n_channels`,`n_samples`)
+            shape = (`n_windows`,`n_channels`,`n_samples`)
         target_freqs : numpy.ndarray
             Target frequencies for the SSVEP.
         fsample : float
@@ -124,19 +124,19 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
             Supertrials of X.
             3D array containing data with `float` type.
 
-            shape = (`num_windows`,`n_channels*number of target_freqs`,
+            shape = (`n_windows`,`n_channels*number of target_freqs`,
             `n_channels*number of target_freqs`)
 
         """
-        num_windows, n_channels, n_samples = X.shape
+        n_windows, n_channels, n_samples = X.shape
         n_target_freqs = len(target_freqs)
 
         super_X = np.zeros(
-            [num_windows, n_channels * n_target_freqs, n_channels * n_target_freqs]
+            [n_windows, n_channels * n_target_freqs, n_channels * n_target_freqs]
         )
 
         # Create super trial of all trials filtered at all bands
-        for window in range(num_windows):
+        for window in range(n_windows):
             for tf, target_freq in enumerate(target_freqs):
                 lower_bound = int((n_channels * tf))
                 upper_bound = int((n_channels * tf) + n_channels)
@@ -184,8 +184,8 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
         # get dimensions
         # X = self.X
 
-        # Convert each window of X into a SPD of dimensions [num_windows, n_channels*nfreqs, n_channels*nfreqs]
-        num_windows, n_channels, n_samples = self.X.shape
+        # Convert each window of X into a SPD of dimensions [n_windows, n_channels*nfreqs, n_channels*nfreqs]
+        n_windows, n_channels, n_samples = self.X.shape
 
         #################
         # Try rebuilding the classifier each time
@@ -196,10 +196,10 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
         # get temporal subset
         subX = self.X[self.next_fit_window :, :, :]
         suby = self.y[self.next_fit_window :]
-        self.next_fit_window = num_windows
+        self.next_fit_window = n_windows
 
         # Init predictions to all false
-        preds = np.zeros(num_windows)
+        preds = np.zeros(n_windows)
 
         def __ssvep_kernel(subX, suby):
             """SSVEP kernel.
@@ -306,7 +306,7 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
 
         # Log performance stats
 
-        self.offline_window_count = num_windows
+        self.offline_window_count = n_windows
         self.offline_window_counts.append(self.offline_window_count)
 
         # accuracy

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -133,7 +133,7 @@ class SwitchDeepClassifier(GenericClassifier):
             self.X = np.array(self.X)
 
         # get dimensions
-        nwindows, nchannels, nsamples = self.X.shape
+        num_windows, num_channels, num_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         X = np.array(self.X)
@@ -171,10 +171,10 @@ class SwitchDeepClassifier(GenericClassifier):
 
             subX = X_class_train[self.next_fit_window :, :, :]
             suby = y_class_train[self.next_fit_window :]
-            self.next_fit_window = nwindows
+            self.next_fit_window = num_windows
 
-            preds = np.zeros((nwindows, self.num_classes))
-            # preds_multiclass = np.zeros(nwindows)
+            preds = np.zeros((num_windows, self.num_classes))
+            # preds_multiclass = np.zeros(num_windows)
 
             for train_idx, test_idx in self.cv.split(subX, suby):
                 X_train, X_test = subX[train_idx], subX[test_idx]
@@ -218,7 +218,7 @@ class SwitchDeepClassifier(GenericClassifier):
 
             logger.info("\nFinished model %s", i + 1)
 
-            self.offline_window_count = nwindows
+            self.offline_window_count = num_windows
             self.offline_window_counts.append(self.offline_window_count)
 
             # accuracy

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -133,7 +133,7 @@ class SwitchDeepClassifier(GenericClassifier):
             self.X = np.array(self.X)
 
         # get dimensions
-        num_windows, num_channels, num_samples = self.X.shape
+        num_windows, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         X = np.array(self.X)
@@ -287,8 +287,8 @@ class SwitchDeepClassifier(GenericClassifier):
 
         # Reshaping data and preprocessing the same way as done in fit
         # Need to review this labelling
-        num_samples, num_channels, num_data_points = X.shape
-        X_predict = X.reshape(num_samples, num_channels * num_data_points)
+        n_samples, n_channels, n_data_points = X.shape
+        X_predict = X.reshape(n_samples, n_channels * n_data_points)
         scaler_train = preprocessing.StandardScaler().fit(X_predict)
         X_predict_scaled = scaler_train.transform(X_predict)
 

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -133,7 +133,7 @@ class SwitchDeepClassifier(GenericClassifier):
             self.X = np.array(self.X)
 
         # get dimensions
-        n_windows, n_channels, n_samples = self.X.shape
+        n_trials, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         X = np.array(self.X)
@@ -167,14 +167,14 @@ class SwitchDeepClassifier(GenericClassifier):
 
             # Try rebuilding the classifier each time
             if self.rebuild:
-                self.next_fit_window = 0
+                self.next_fit_trial = 0
 
-            subX = X_class_train[self.next_fit_window :, :, :]
-            suby = y_class_train[self.next_fit_window :]
-            self.next_fit_window = n_windows
+            subX = X_class_train[self.next_fit_trial :, :, :]
+            suby = y_class_train[self.next_fit_trial :]
+            self.next_fit_trial = n_trials
 
-            preds = np.zeros((n_windows, self.num_classes))
-            # preds_multiclass = np.zeros(n_windows)
+            preds = np.zeros((n_trials, self.num_classes))
+            # preds_multiclass = np.zeros(n_trials)
 
             for train_idx, test_idx in self.cv.split(subX, suby):
                 X_train, X_test = subX[train_idx], subX[test_idx]
@@ -218,8 +218,8 @@ class SwitchDeepClassifier(GenericClassifier):
 
             logger.info("\nFinished model %s", i + 1)
 
-            self.offline_window_count = n_windows
-            self.offline_window_counts.append(self.offline_window_count)
+            self.offline_trial_count = n_trials
+            self.offline_trial_counts.append(self.offline_trial_count)
 
             # accuracy
             z_dim, y_dim, x_dim = X_class_test.shape
@@ -269,7 +269,7 @@ class SwitchDeepClassifier(GenericClassifier):
         Parameters
         ----------
         X : np.ndarray
-            3D array where shape = (windows, channels, samples)
+            3D array where shape = (trials, channels, samples)
 
         Returns
         -------

--- a/bci_essentials/classification/switch_deep_classifier.py
+++ b/bci_essentials/classification/switch_deep_classifier.py
@@ -133,7 +133,7 @@ class SwitchDeepClassifier(GenericClassifier):
             self.X = np.array(self.X)
 
         # get dimensions
-        num_windows, n_channels, n_samples = self.X.shape
+        n_windows, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         X = np.array(self.X)
@@ -171,10 +171,10 @@ class SwitchDeepClassifier(GenericClassifier):
 
             subX = X_class_train[self.next_fit_window :, :, :]
             suby = y_class_train[self.next_fit_window :]
-            self.next_fit_window = num_windows
+            self.next_fit_window = n_windows
 
-            preds = np.zeros((num_windows, self.num_classes))
-            # preds_multiclass = np.zeros(num_windows)
+            preds = np.zeros((n_windows, self.num_classes))
+            # preds_multiclass = np.zeros(n_windows)
 
             for train_idx, test_idx in self.cv.split(subX, suby):
                 X_train, X_test = subX[train_idx], subX[test_idx]
@@ -218,7 +218,7 @@ class SwitchDeepClassifier(GenericClassifier):
 
             logger.info("\nFinished model %s", i + 1)
 
-            self.offline_window_count = num_windows
+            self.offline_window_count = n_windows
             self.offline_window_counts.append(self.offline_window_count)
 
             # accuracy

--- a/bci_essentials/classification/switch_mdm_classifier.py
+++ b/bci_essentials/classification/switch_mdm_classifier.py
@@ -90,7 +90,7 @@ class SwitchMdmClassifier(GenericClassifier):
 
         """
         # get dimensions
-        num_windows, num_channels, num_samples = self.X.shape
+        num_windows, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         X = np.array(self.X)

--- a/bci_essentials/classification/switch_mdm_classifier.py
+++ b/bci_essentials/classification/switch_mdm_classifier.py
@@ -90,7 +90,7 @@ class SwitchMdmClassifier(GenericClassifier):
 
         """
         # get dimensions
-        nwindows, nchannels, nsamples = self.X.shape
+        num_windows, num_channels, num_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         X = np.array(self.X)
@@ -119,7 +119,7 @@ class SwitchMdmClassifier(GenericClassifier):
 
             subX = X_class[self.next_fit_window :, :, :]
             suby = y_class[self.next_fit_window :]
-            self.next_fit_window = nwindows
+            self.next_fit_window = num_windows
 
             for train_idx, test_idx in self.cv.split(subX, suby):
                 X_train, X_test = subX[train_idx], subX[test_idx]
@@ -182,7 +182,7 @@ class SwitchMdmClassifier(GenericClassifier):
 
             # COMMENTED OUT DUE TO INCOMPLETE IMPLEMENTATION
             """
-            self.offline_window_count = nwindows
+            self.offline_window_count = num_windows
             self.offline_window_counts.append(self.offline_window_count)
             # accuracy
             accuracy = sum(preds == self.y) / len(preds)

--- a/bci_essentials/classification/switch_mdm_classifier.py
+++ b/bci_essentials/classification/switch_mdm_classifier.py
@@ -90,7 +90,7 @@ class SwitchMdmClassifier(GenericClassifier):
 
         """
         # get dimensions
-        num_windows, n_channels, n_samples = self.X.shape
+        n_windows, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         X = np.array(self.X)
@@ -119,7 +119,7 @@ class SwitchMdmClassifier(GenericClassifier):
 
             subX = X_class[self.next_fit_window :, :, :]
             suby = y_class[self.next_fit_window :]
-            self.next_fit_window = num_windows
+            self.next_fit_window = n_windows
 
             for train_idx, test_idx in self.cv.split(subX, suby):
                 X_train, X_test = subX[train_idx], subX[test_idx]
@@ -182,7 +182,7 @@ class SwitchMdmClassifier(GenericClassifier):
 
             # COMMENTED OUT DUE TO INCOMPLETE IMPLEMENTATION
             """
-            self.offline_window_count = num_windows
+            self.offline_window_count = n_windows
             self.offline_window_counts.append(self.offline_window_count)
             # accuracy
             accuracy = sum(preds == self.y) / len(preds)

--- a/bci_essentials/classification/switch_mdm_classifier.py
+++ b/bci_essentials/classification/switch_mdm_classifier.py
@@ -90,7 +90,7 @@ class SwitchMdmClassifier(GenericClassifier):
 
         """
         # get dimensions
-        n_windows, n_channels, n_samples = self.X.shape
+        n_trials, n_channels, n_samples = self.X.shape
 
         # do the rest of the training if train_free is false
         X = np.array(self.X)
@@ -114,12 +114,12 @@ class SwitchMdmClassifier(GenericClassifier):
 
             # Try rebuilding the classifier each time
             if self.rebuild:
-                self.next_fit_window = 0
+                self.next_fit_trial = 0
                 # tf.keras.backend.clear_session()
 
-            subX = X_class[self.next_fit_window :, :, :]
-            suby = y_class[self.next_fit_window :]
-            self.next_fit_window = n_windows
+            subX = X_class[self.next_fit_trial :, :, :]
+            suby = y_class[self.next_fit_trial :]
+            self.next_fit_trial = n_trials
 
             for train_idx, test_idx in self.cv.split(subX, suby):
                 X_train, X_test = subX[train_idx], subX[test_idx]
@@ -182,8 +182,8 @@ class SwitchMdmClassifier(GenericClassifier):
 
             # COMMENTED OUT DUE TO INCOMPLETE IMPLEMENTATION
             """
-            self.offline_window_count = n_windows
-            self.offline_window_counts.append(self.offline_window_count)
+            self.offline_trial_count = n_trials
+            self.offline_trial_counts.append(self.offline_trial_count)
             # accuracy
             accuracy = sum(preds == self.y) / len(preds)
             self.offline_accuracy.append(accuracy)
@@ -208,7 +208,7 @@ class SwitchMdmClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (windows, channels, samples)
+            3D array where shape = (trials, channels, samples)
 
         Returns
         -------

--- a/bci_essentials/eeg_data.py
+++ b/bci_essentials/eeg_data.py
@@ -485,7 +485,9 @@ class EegData:
                 duration = np.floor(eyes_closed_end_time[0] - eyes_closed_start_time[0])
                 num_samples = int(duration * self.fsample)
 
-                self.eyes_closed_timestamps = np.array(range(num_samples)) / self.fsample
+                self.eyes_closed_timestamps = (
+                    np.array(range(num_samples)) / self.fsample
+                )
                 self.eyes_closed_windows = np.ndarray(
                     (len(eyes_closed_start_time), self.num_channels, num_samples)
                 )
@@ -798,7 +800,9 @@ class EegData:
                             0 : self.num_samples,
                         ]
                     )
-                    self.current_labels = self.current_labels[0 : self.current_num_windows]
+                    self.current_labels = self.current_labels[
+                        0 : self.current_num_windows
+                    ]
 
                     # TRAIN
                     if self.training:
@@ -845,7 +849,10 @@ class EegData:
 
                         # save the online selection indices
                         selection_inds = list(
-                            range(self.num_windows - self.current_num_windows, self.num_windows)
+                            range(
+                                self.num_windows - self.current_num_windows,
+                                self.num_windows,
+                            )
                         )
                         self.online_selection_indices.append(selection_inds)
 
@@ -1040,7 +1047,9 @@ class EegData:
             ] = self.current_processed_eeg_windows[
                 self.current_num_windows, 0 : self.num_channels, 0 : self.num_samples
             ]
-            self.labels[self.num_windows] = self.current_labels[self.current_num_windows]
+            self.labels[self.num_windows] = self.current_labels[
+                self.current_num_windows
+            ]
 
             # Send live updates
             if self.live_update:

--- a/bci_essentials/eeg_data.py
+++ b/bci_essentials/eeg_data.py
@@ -682,7 +682,7 @@ class EegData:
         # initialize the numbers of markers and windows to zero
         self.marker_count = 0
         self.current_num_windows = 0
-        self.num_windows = 0
+        self.n_windows = 0
 
         self.num_online_selections = 0
         self.online_selection_indices = []
@@ -729,12 +729,12 @@ class EegData:
 
         # Trim all the data
         self.raw_eeg_windows = self.raw_eeg_windows[
-            0 : self.num_windows, 0 : self.n_channels, 0 : self.n_samples
+            0 : self.n_windows, 0 : self.n_channels, 0 : self.n_samples
         ]
         self.processed_eeg_windows = self.processed_eeg_windows[
-            0 : self.num_windows, 0 : self.n_channels, 0 : self.n_samples
+            0 : self.n_windows, 0 : self.n_channels, 0 : self.n_samples
         ]
-        self.labels = self.labels[0 : self.num_windows]
+        self.labels = self.labels[0 : self.n_windows]
 
     def step(self):
         """Runs a single EegData processing step.
@@ -850,8 +850,8 @@ class EegData:
                         # save the online selection indices
                         selection_inds = list(
                             range(
-                                self.num_windows - self.current_num_windows,
-                                self.num_windows,
+                                self.n_windows - self.current_num_windows,
+                                self.n_windows,
                             )
                         )
                         self.online_selection_indices.append(selection_inds)
@@ -1038,16 +1038,16 @@ class EegData:
 
             # copy to the eeg_data object
             self.raw_eeg_windows[
-                self.num_windows, 0 : self.n_channels, 0 : self.n_samples
+                self.n_windows, 0 : self.n_channels, 0 : self.n_samples
             ] = self.current_raw_eeg_windows[
                 self.current_num_windows, 0 : self.n_channels, 0 : self.n_samples
             ]
             self.processed_eeg_windows[
-                self.num_windows, 0 : self.n_channels, 0 : self.n_samples
+                self.n_windows, 0 : self.n_channels, 0 : self.n_samples
             ] = self.current_processed_eeg_windows[
                 self.current_num_windows, 0 : self.n_channels, 0 : self.n_samples
             ]
-            self.labels[self.num_windows] = self.current_labels[
+            self.labels[self.n_windows] = self.current_labels[
                 self.current_num_windows
             ]
 
@@ -1069,5 +1069,5 @@ class EegData:
             # iterate to next window
             self.marker_count += 1
             self.current_num_windows += 1
-            self.num_windows += 1
+            self.n_windows += 1
             self.search_index = start_loc

--- a/bci_essentials/eeg_data.py
+++ b/bci_essentials/eeg_data.py
@@ -485,9 +485,7 @@ class EegData:
                 duration = np.floor(eyes_closed_end_time[0] - eyes_closed_start_time[0])
                 n_samples = int(duration * self.fsample)
 
-                self.eyes_closed_timestamps = (
-                    np.array(range(n_samples)) / self.fsample
-                )
+                self.eyes_closed_timestamps = np.array(range(n_samples)) / self.fsample
                 self.eyes_closed_trials = np.ndarray(
                     (len(eyes_closed_start_time), self.n_channels, n_samples)
                 )
@@ -1047,9 +1045,7 @@ class EegData:
             ] = self.current_processed_eeg_trials[
                 self.current_num_trials, 0 : self.n_channels, 0 : self.n_samples
             ]
-            self.labels[self.n_trials] = self.current_labels[
-                self.current_num_trials
-            ]
+            self.labels[self.n_trials] = self.current_labels[self.current_num_trials]
 
             # Send live updates
             if self.live_update:

--- a/bci_essentials/erp_data.py
+++ b/bci_essentials/erp_data.py
@@ -167,7 +167,7 @@ class ErpData(EegData):
 
         # initialize the numbers of markers, windows, and decision blocks to zero
         self.marker_count = 0
-        self.num_windows = 0
+        self.n_windows = 0
         self.decision_count = 0
 
         self.training_labels = np.zeros((self.max_windows), dtype=int)
@@ -248,16 +248,16 @@ class ErpData(EegData):
 
         # Trim the unused ends of numpy arrays
         if self.training:
-            self.training_labels = self.training_labels[0 : self.num_windows - 1]
-            self.target_index = self.target_index[0 : self.num_windows - 1]
+            self.training_labels = self.training_labels[0 : self.n_windows - 1]
+            self.target_index = self.target_index[0 : self.n_windows - 1]
 
-        # self.erp_windows = self.erp_windows[0:self.num_windows, 0:self.n_channels, 0:self.n_samples]
+        # self.erp_windows = self.erp_windows[0:self.n_windows, 0:self.n_channels, 0:self.n_samples]
         self.erp_windows_raw = self.erp_windows_raw[
-            0 : self.num_windows, 0 : self.n_channels, 0 : self.n_samples
+            0 : self.n_windows, 0 : self.n_channels, 0 : self.n_samples
         ]
-        self.target_index = self.target_index[0 : self.num_windows]
-        self.training_labels = self.training_labels[0 : self.num_windows]
-        self.stim_labels = self.stim_labels[0 : self.num_windows, :]
+        self.target_index = self.target_index[0 : self.n_windows]
+        self.training_labels = self.training_labels[0 : self.n_windows]
+        self.stim_labels = self.stim_labels[0 : self.n_windows, :]
         self.num_options_per_decision = self.num_options_per_decision[
             0 : self.decision_count
         ]
@@ -523,15 +523,15 @@ class ErpData(EegData):
                     logger.info("Marker information: %s", current_marker_info)
                     current_target = self.unity_label
 
-                self.training_labels[self.num_windows] = current_target
+                self.training_labels[self.n_windows] = current_target
 
                 for fi in flash_indices:
-                    self.stim_labels[self.num_windows, fi] = True
+                    self.stim_labels[self.n_windows, fi] = True
 
                 if current_target in flash_indices:
-                    self.target_index[self.num_windows] = True
+                    self.target_index[self.n_windows] = True
                 else:
-                    self.target_index[self.num_windows] = False
+                    self.target_index[self.n_windows] = False
 
             # Find the start time and end time for the window based on the marker timestamp
             start_time = self.marker_timestamps[self.marker_count] + self.window_start
@@ -570,9 +570,9 @@ class ErpData(EegData):
 
                     # add to raw ERP windows
                     self.erp_windows_raw[
-                        self.num_windows, c, 0 : self.n_samples
+                        self.n_windows, c, 0 : self.n_samples
                     ] = channel_data
-                    # self.decision_blocks_raw[self.decision_count, self.num_windows, c, 0:self.n_samples]
+                    # self.decision_blocks_raw[self.decision_count, self.n_windows, c, 0:self.n_samples]
 
                     # if self.pp_type == "bandpass":
                     #     channel_data_2 = bandpass(channel_data[np.newaxis,:], self.pp_low, self.pp_high, self.pp_order, self.fsample)
@@ -593,17 +593,17 @@ class ErpData(EegData):
                             self.non_target_plot = flash_index
 
                     # # add to processed ERP windows
-                    # self.erp_windows[self.num_windows, c, 0:self.n_samples] = channel_data
+                    # self.erp_windows[self.n_windows, c, 0:self.n_samples] = channel_data
 
                     # # Does the ensemble avearging
                     # self.decision_blocks[self.decision_count, flash_index, c, 0:self.n_samples] += channel_data
 
                 # This is where to do preprocessing
                 self.erp_windows_processed[
-                    self.num_windows, : self.n_channels, : self.n_samples
+                    self.n_windows, : self.n_channels, : self.n_samples
                 ] = self._preprocessing(
                     window=self.erp_windows_raw[
-                        self.num_windows, : self.n_channels, : self.n_samples
+                        self.n_windows, : self.n_channels, : self.n_samples
                     ],
                     option=self.pp_type,
                     order=self.pp_order,
@@ -613,10 +613,10 @@ class ErpData(EegData):
 
                 # This is where to do artefact rejection
                 self.erp_windows_processed[
-                    self.num_windows, : self.n_channels, : self.n_samples
+                    self.n_windows, : self.n_channels, : self.n_samples
                 ] = self._artefact_rejection(
                     window=self.erp_windows_processed[
-                        self.num_windows, : self.n_channels, : self.n_samples
+                        self.n_windows, : self.n_channels, : self.n_samples
                     ],
                     option=None,
                 )
@@ -630,7 +630,7 @@ class ErpData(EegData):
                     0 : self.n_channels,
                     0 : self.n_samples,
                 ] = self.erp_windows_raw[
-                    self.num_windows, : self.n_channels, : self.n_samples
+                    self.n_windows, : self.n_channels, : self.n_samples
                 ]
 
                 self.big_decision_blocks_processed[
@@ -640,7 +640,7 @@ class ErpData(EegData):
                     0 : self.n_channels,
                     0 : self.n_samples,
                 ] = self.erp_windows_processed[
-                    self.num_windows, : self.n_channels, : self.n_samples
+                    self.n_windows, : self.n_channels, : self.n_samples
                 ]
 
                 # self.windows_per_decision[flash_index] += 1
@@ -648,7 +648,7 @@ class ErpData(EegData):
 
             # iterate to next window
             self.marker_count += 1
-            self.num_windows += 1
+            self.n_windows += 1
             self.search_index = start_loc
             if self.online:
                 time.sleep(0.000001)

--- a/bci_essentials/erp_data.py
+++ b/bci_essentials/erp_data.py
@@ -148,13 +148,13 @@ class ErpData(EegData):
         # plot settings
         self.plot_erp = plot_erp
         if self.plot_erp:
-            self.fig1, self.axs1 = plt.subplots(self.num_channels)
-            self.fig2, self.axs2 = plt.subplots(self.num_channels)
+            self.fig1, self.axs1 = plt.subplots(self.n_channels)
+            self.fig2, self.axs2 = plt.subplots(self.n_channels)
             self.non_target_plot = 99
 
         # iff this is the first time this function is being called for a given dataset
         self.window_size = self.window_end - self.window_start
-        self.num_samples = int(np.ceil(self.window_size * self.fsample) + 1)
+        self.n_samples = int(np.ceil(self.window_size * self.fsample) + 1)
         self.window_end_buffer = self.buffer_time
         self.num_options = max_num_options
         self.max_windows = max_windows
@@ -163,7 +163,7 @@ class ErpData(EegData):
 
         self.search_index = 0
 
-        self.window_timestamps = np.arange(self.num_samples) / self.fsample
+        self.window_timestamps = np.arange(self.n_samples) / self.fsample
 
         # initialize the numbers of markers, windows, and decision blocks to zero
         self.marker_count = 0
@@ -177,10 +177,10 @@ class ErpData(EegData):
         # initialize the data structures in numpy arrays
         # ERP windows
         self.erp_windows_raw = np.zeros(
-            (self.max_windows, self.num_channels, self.num_samples)
+            (self.max_windows, self.n_channels, self.n_samples)
         )
         self.erp_windows_processed = np.zeros(
-            (self.max_windows, self.num_channels, self.num_samples)
+            (self.max_windows, self.n_channels, self.n_samples)
         )
 
         # Windows per decision, ie. the number of times each stimulus has flashed
@@ -188,10 +188,10 @@ class ErpData(EegData):
 
         # Decision blocks are the ensemble averages of all windows collected for each stimulus object
         self.decision_blocks_raw = np.ndarray(
-            (self.max_decisions, self.num_options, self.num_channels, self.num_samples)
+            (self.max_decisions, self.num_options, self.n_channels, self.n_samples)
         )
         self.decision_blocks_processed = np.ndarray(
-            (self.max_decisions, self.num_options, self.num_channels, self.num_samples)
+            (self.max_decisions, self.num_options, self.n_channels, self.n_samples)
         )
 
         # Big decision blocks contain all decisions, all stimulus objects, all windows, all channels, and all samples (they are BIG)
@@ -200,8 +200,8 @@ class ErpData(EegData):
                 self.max_decisions,
                 self.num_options,
                 self.max_windows_per_option,
-                self.num_channels,
-                self.num_samples,
+                self.n_channels,
+                self.n_samples,
             )
         )
         self.big_decision_blocks_processed = np.ndarray(
@@ -209,8 +209,8 @@ class ErpData(EegData):
                 self.max_decisions,
                 self.num_options,
                 self.max_windows_per_option,
-                self.num_channels,
-                self.num_samples,
+                self.n_channels,
+                self.n_samples,
             )
         )
 
@@ -251,9 +251,9 @@ class ErpData(EegData):
             self.training_labels = self.training_labels[0 : self.num_windows - 1]
             self.target_index = self.target_index[0 : self.num_windows - 1]
 
-        # self.erp_windows = self.erp_windows[0:self.num_windows, 0:self.num_channels, 0:self.num_samples]
+        # self.erp_windows = self.erp_windows[0:self.num_windows, 0:self.n_channels, 0:self.n_samples]
         self.erp_windows_raw = self.erp_windows_raw[
-            0 : self.num_windows, 0 : self.num_channels, 0 : self.num_samples
+            0 : self.num_windows, 0 : self.n_channels, 0 : self.n_samples
         ]
         self.target_index = self.target_index[0 : self.num_windows]
         self.training_labels = self.training_labels[0 : self.num_windows]
@@ -262,16 +262,16 @@ class ErpData(EegData):
             0 : self.decision_count
         ]
         self.decision_blocks_raw = self.decision_blocks_raw[
-            0 : self.decision_count, :, 0 : self.num_channels, 0 : self.num_samples
+            0 : self.decision_count, :, 0 : self.n_channels, 0 : self.n_samples
         ]
         self.decision_blocks_processed = self.decision_blocks_processed[
-            0 : self.decision_count, :, 0 : self.num_channels, 0 : self.num_samples
+            0 : self.decision_count, :, 0 : self.n_channels, 0 : self.n_samples
         ]
         self.big_decision_blocks_raw = self.big_decision_blocks_raw[
-            0 : self.decision_count, :, :, 0 : self.num_channels, 0 : self.num_samples
+            0 : self.decision_count, :, :, 0 : self.n_channels, 0 : self.n_samples
         ]
         self.big_decision_blocks_processed = self.big_decision_blocks_processed[
-            0 : self.decision_count, :, :, 0 : self.num_channels, 0 : self.num_samples
+            0 : self.decision_count, :, :, 0 : self.n_channels, 0 : self.n_samples
         ]
 
     def step(self):
@@ -345,16 +345,16 @@ class ErpData(EegData):
                             self.decision_count,
                             0 : self.num_options,
                             0:num_ensemble_windows,
-                            0 : self.num_channels,
-                            0 : self.num_samples,
+                            0 : self.n_channels,
+                            0 : self.n_samples,
                         ],
                         axis=1,
                     )
                     self.decision_blocks_raw[
                         self.decision_count,
                         0 : self.num_options,
-                        0 : self.num_channels,
-                        0 : self.num_samples,
+                        0 : self.n_channels,
+                        0 : self.n_samples,
                     ] = ensemble_average_block
 
                     # Processed ensemble average
@@ -363,16 +363,16 @@ class ErpData(EegData):
                             self.decision_count,
                             0 : self.num_options,
                             0:num_ensemble_windows,
-                            0 : self.num_channels,
-                            0 : self.num_samples,
+                            0 : self.n_channels,
+                            0 : self.n_samples,
                         ],
                         axis=1,
                     )
                     self.decision_blocks_processed[
                         self.decision_count,
                         0 : self.num_options,
-                        0 : self.num_channels,
-                        0 : self.num_samples,
+                        0 : self.n_channels,
+                        0 : self.n_samples,
                     ] = ensemble_average_block
 
                     # Reset windows per decision
@@ -548,7 +548,7 @@ class ErpData(EegData):
                     #     start_loc = 0
 
                     break
-            end_loc = start_loc + self.num_samples + 1
+            end_loc = start_loc + self.n_samples + 1
 
             # Adjust windows per option
             # self.windows_per_option = np.zeros(self.num_options, dtype=int)
@@ -556,7 +556,7 @@ class ErpData(EegData):
             logger.debug("Window (start_loc, end_loc): (%s, %s)", start_loc, end_loc)
             # linear interpolation and add to numpy array
             for flash_index in flash_indices:
-                for c in range(self.num_channels):
+                for c in range(self.n_channels):
                     eeg_timestamps_adjusted = (
                         self.eeg_timestamps[start_loc:end_loc]
                         - self.eeg_timestamps[start_loc]
@@ -570,9 +570,9 @@ class ErpData(EegData):
 
                     # add to raw ERP windows
                     self.erp_windows_raw[
-                        self.num_windows, c, 0 : self.num_samples
+                        self.num_windows, c, 0 : self.n_samples
                     ] = channel_data
-                    # self.decision_blocks_raw[self.decision_count, self.num_windows, c, 0:self.num_samples]
+                    # self.decision_blocks_raw[self.decision_count, self.num_windows, c, 0:self.n_samples]
 
                     # if self.pp_type == "bandpass":
                     #     channel_data_2 = bandpass(channel_data[np.newaxis,:], self.pp_low, self.pp_high, self.pp_order, self.fsample)
@@ -583,27 +583,27 @@ class ErpData(EegData):
 
                     if self.plot_erp:
                         if flash_index == current_target:
-                            self.axs1[c].plot(range(self.num_samples), channel_data)
+                            self.axs1[c].plot(range(self.n_samples), channel_data)
 
                         elif (
                             self.non_target_plot == 99
                             or self.non_target_plot == flash_index
                         ):
-                            self.axs2[c].plot(range(self.num_samples), channel_data)
+                            self.axs2[c].plot(range(self.n_samples), channel_data)
                             self.non_target_plot = flash_index
 
                     # # add to processed ERP windows
-                    # self.erp_windows[self.num_windows, c, 0:self.num_samples] = channel_data
+                    # self.erp_windows[self.num_windows, c, 0:self.n_samples] = channel_data
 
                     # # Does the ensemble avearging
-                    # self.decision_blocks[self.decision_count, flash_index, c, 0:self.num_samples] += channel_data
+                    # self.decision_blocks[self.decision_count, flash_index, c, 0:self.n_samples] += channel_data
 
                 # This is where to do preprocessing
                 self.erp_windows_processed[
-                    self.num_windows, : self.num_channels, : self.num_samples
+                    self.num_windows, : self.n_channels, : self.n_samples
                 ] = self._preprocessing(
                     window=self.erp_windows_raw[
-                        self.num_windows, : self.num_channels, : self.num_samples
+                        self.num_windows, : self.n_channels, : self.n_samples
                     ],
                     option=self.pp_type,
                     order=self.pp_order,
@@ -613,34 +613,34 @@ class ErpData(EegData):
 
                 # This is where to do artefact rejection
                 self.erp_windows_processed[
-                    self.num_windows, : self.num_channels, : self.num_samples
+                    self.num_windows, : self.n_channels, : self.n_samples
                 ] = self._artefact_rejection(
                     window=self.erp_windows_processed[
-                        self.num_windows, : self.num_channels, : self.num_samples
+                        self.num_windows, : self.n_channels, : self.n_samples
                     ],
                     option=None,
                 )
 
                 # Add the raw window to the raw decision blocks
-                # self.decision_blocks_raw[self.decision_count, flash_index, 0:self.num_channels, 0:self.num_samples] +=  self.erp_windows_processed
+                # self.decision_blocks_raw[self.decision_count, flash_index, 0:self.n_channels, 0:self.n_samples] +=  self.erp_windows_processed
                 self.big_decision_blocks_raw[
                     self.decision_count,
                     flash_index,
                     int(self.windows_per_decision[flash_index] - 1),
-                    0 : self.num_channels,
-                    0 : self.num_samples,
+                    0 : self.n_channels,
+                    0 : self.n_samples,
                 ] = self.erp_windows_raw[
-                    self.num_windows, : self.num_channels, : self.num_samples
+                    self.num_windows, : self.n_channels, : self.n_samples
                 ]
 
                 self.big_decision_blocks_processed[
                     self.decision_count,
                     flash_index,
                     int(self.windows_per_decision[flash_index] - 1),
-                    0 : self.num_channels,
-                    0 : self.num_samples,
+                    0 : self.n_channels,
+                    0 : self.n_samples,
                 ] = self.erp_windows_processed[
-                    self.num_windows, : self.num_channels, : self.num_samples
+                    self.num_windows, : self.n_channels, : self.n_samples
                 ]
 
                 # self.windows_per_decision[flash_index] += 1

--- a/bci_essentials/erp_data.py
+++ b/bci_essentials/erp_data.py
@@ -8,7 +8,7 @@ or the live streaming of LSL data.
 The loaded/streamed data is added to a buffer such that offline and
 online processing pipelines are identical.
 
-Data is pre-processed (using the `signal_processing` module), windowed,
+Data is pre-processed (using the `signal_processing` module), separated into trials,
 and classified (using one of the `classification` sub-modules).
 
 Classes
@@ -33,18 +33,18 @@ logger = Logger(name=__name__)
 # ERP Data
 class ErpData(EegData):
     """
-    Class that holds, windows, processes and classifies ERP data.
+    Class that holds, trials, processes and classifies ERP data.
     """
 
     # Formats the ERP data, call this every time that a new chunk arrives
     def setup(
         self,
-        window_start=0.0,
-        window_end=0.8,
+        trial_start=0.0,
+        trial_end=0.8,
         buffer_time=0.01,
         max_num_options=64,
-        max_windows_per_option=50,
-        max_windows=10000,
+        max_trials_per_option=50,
+        max_trials=10000,
         max_decisions=500,
         training=False,
         train_complete=False,
@@ -59,7 +59,7 @@ class ErpData(EegData):
 
         Formats the ERP data. Call this every time that a new chunk arrives.
 
-        Runs a while loop that reads in ERP windows. The loop can be run in
+        Runs a while loop that reads in ERP trials. The loop can be run in
         "offline" or "online" modes:
         - If in `online` mode, then the loop will continuously try to read
         in data from the `EegData` object and process it. The loop will
@@ -69,11 +69,11 @@ class ErpData(EegData):
 
         Parameters
         ----------
-        window_start : float, *optional*
-            Start time for ERP sampling window relative to marker (seconds).
+        trial_start : float, *optional*
+            Start time for ERP sampling trial relative to marker (seconds).
             - Default is `0.0`.
-        window_end : float, *optional*
-            End time for ERP sampling window relative to marker (seconds).
+        trial_end : float, *optional*
+            End time for ERP sampling trial relative to marker (seconds).
             - Default is `0.8`.
         buffer : float, *optional*
             Buffer time for EEG sampling in `online` mode (seconds).
@@ -81,11 +81,11 @@ class ErpData(EegData):
         max_num_options : int, *optional*
             Maximum number of stimulus options (?).
             - Default is `64`.
-        max_windows_per_option : int, *optional*
-            Maximum number of windows to read in per stimulus option (?).
+        max_trials_per_option : int, *optional*
+            Maximum number of trials to read in per stimulus option (?).
             - Default is `50`.
-        max_windows : int, *optional*
-            Maximum number of windows to read in per loop (?).
+        max_trials : int, *optional*
+            Maximum number of trials to read in per loop (?).
             - Default is `1000`.
         max_decisions : int, *optional*
             Maximum number of ERP decision blocks to store per loop (?).
@@ -129,8 +129,8 @@ class ErpData(EegData):
 
         """
 
-        self.window_start = window_start
-        self.window_end = window_end
+        self.trial_start = trial_start
+        self.trial_end = trial_end
         self.buffer_time = buffer_time
 
         self.training = training
@@ -153,40 +153,40 @@ class ErpData(EegData):
             self.non_target_plot = 99
 
         # iff this is the first time this function is being called for a given dataset
-        self.window_size = self.window_end - self.window_start
-        self.n_samples = int(np.ceil(self.window_size * self.fsample) + 1)
-        self.window_end_buffer = self.buffer_time
+        self.trial_size = self.trial_end - self.trial_start
+        self.n_samples = int(np.ceil(self.trial_size * self.fsample) + 1)
+        self.trial_end_buffer = self.buffer_time
         self.num_options = max_num_options
-        self.max_windows = max_windows
-        self.max_windows_per_option = max_windows_per_option
+        self.max_trials = max_trials
+        self.max_trials_per_option = max_trials_per_option
         self.max_decisions = max_decisions
 
         self.search_index = 0
 
-        self.window_timestamps = np.arange(self.n_samples) / self.fsample
+        self.trial_timestamps = np.arange(self.n_samples) / self.fsample
 
-        # initialize the numbers of markers, windows, and decision blocks to zero
+        # initialize the numbers of markers, trials, and decision blocks to zero
         self.marker_count = 0
-        self.n_windows = 0
+        self.n_trials = 0
         self.decision_count = 0
 
-        self.training_labels = np.zeros((self.max_windows), dtype=int)
-        self.stim_labels = np.zeros((self.max_windows, self.num_options), dtype=bool)
-        self.target_index = np.ndarray((self.max_windows), bool)
+        self.training_labels = np.zeros((self.max_trials), dtype=int)
+        self.stim_labels = np.zeros((self.max_trials, self.num_options), dtype=bool)
+        self.target_index = np.ndarray((self.max_trials), bool)
 
         # initialize the data structures in numpy arrays
-        # ERP windows
-        self.erp_windows_raw = np.zeros(
-            (self.max_windows, self.n_channels, self.n_samples)
+        # ERP trials
+        self.erp_trials_raw = np.zeros(
+            (self.max_trials, self.n_channels, self.n_samples)
         )
-        self.erp_windows_processed = np.zeros(
-            (self.max_windows, self.n_channels, self.n_samples)
+        self.erp_trials_processed = np.zeros(
+            (self.max_trials, self.n_channels, self.n_samples)
         )
 
-        # Windows per decision, ie. the number of times each stimulus has flashed
-        self.windows_per_decision = np.zeros((self.num_options))
+        # Trials per decision, ie. the number of times each stimulus has flashed
+        self.trials_per_decision = np.zeros((self.num_options))
 
-        # Decision blocks are the ensemble averages of all windows collected for each stimulus object
+        # Decision blocks are the ensemble averages of all trials collected for each stimulus object
         self.decision_blocks_raw = np.ndarray(
             (self.max_decisions, self.num_options, self.n_channels, self.n_samples)
         )
@@ -194,12 +194,12 @@ class ErpData(EegData):
             (self.max_decisions, self.num_options, self.n_channels, self.n_samples)
         )
 
-        # Big decision blocks contain all decisions, all stimulus objects, all windows, all channels, and all samples (they are BIG)
+        # Big decision blocks contain all decisions, all stimulus objects, all trials, all channels, and all samples (they are BIG)
         self.big_decision_blocks_raw = np.ndarray(
             (
                 self.max_decisions,
                 self.num_options,
-                self.max_windows_per_option,
+                self.max_trials_per_option,
                 self.n_channels,
                 self.n_samples,
             )
@@ -208,7 +208,7 @@ class ErpData(EegData):
             (
                 self.max_decisions,
                 self.num_options,
-                self.max_windows_per_option,
+                self.max_trials_per_option,
                 self.n_channels,
                 self.n_samples,
             )
@@ -248,16 +248,16 @@ class ErpData(EegData):
 
         # Trim the unused ends of numpy arrays
         if self.training:
-            self.training_labels = self.training_labels[0 : self.n_windows - 1]
-            self.target_index = self.target_index[0 : self.n_windows - 1]
+            self.training_labels = self.training_labels[0 : self.n_trials - 1]
+            self.target_index = self.target_index[0 : self.n_trials - 1]
 
-        # self.erp_windows = self.erp_windows[0:self.n_windows, 0:self.n_channels, 0:self.n_samples]
-        self.erp_windows_raw = self.erp_windows_raw[
-            0 : self.n_windows, 0 : self.n_channels, 0 : self.n_samples
+        # self.erp_trials = self.erp_trials[0:self.n_trials, 0:self.n_channels, 0:self.n_samples]
+        self.erp_trials_raw = self.erp_trials_raw[
+            0 : self.n_trials, 0 : self.n_channels, 0 : self.n_samples
         ]
-        self.target_index = self.target_index[0 : self.n_windows]
-        self.training_labels = self.training_labels[0 : self.n_windows]
-        self.stim_labels = self.stim_labels[0 : self.n_windows, :]
+        self.target_index = self.target_index[0 : self.n_trials]
+        self.training_labels = self.training_labels[0 : self.n_trials]
+        self.stim_labels = self.stim_labels[0 : self.n_trials, :]
         self.num_options_per_decision = self.num_options_per_decision[
             0 : self.decision_count
         ]
@@ -331,8 +331,8 @@ class ErpData(EegData):
                     current_step_marker == "P300 SingleFlash Ends"
                     or current_step_marker == "Trial Ends"
                 ):
-                    # get the smallest number of windows per decision in the case the are not the same
-                    num_ensemble_windows = int(np.min(self.windows_per_decision))
+                    # get the smallest number of trials per decision in the case the are not the same
+                    num_ensemble_trials = int(np.min(self.trials_per_decision))
 
                     # save the number of options
                     self.num_options_per_decision[self.decision_count] = int(
@@ -344,7 +344,7 @@ class ErpData(EegData):
                         self.big_decision_blocks_raw[
                             self.decision_count,
                             0 : self.num_options,
-                            0:num_ensemble_windows,
+                            0:num_ensemble_trials,
                             0 : self.n_channels,
                             0 : self.n_samples,
                         ],
@@ -362,7 +362,7 @@ class ErpData(EegData):
                         self.big_decision_blocks_processed[
                             self.decision_count,
                             0 : self.num_options,
-                            0:num_ensemble_windows,
+                            0:num_ensemble_trials,
                             0 : self.n_channels,
                             0 : self.n_samples,
                         ],
@@ -375,8 +375,8 @@ class ErpData(EegData):
                         0 : self.n_samples,
                     ] = ensemble_average_block
 
-                    # Reset windows per decision
-                    self.windows_per_decision = np.zeros((self.num_options))
+                    # Reset trials per decision
+                    self.trials_per_decision = np.zeros((self.num_options))
 
                     if self.plot_erp:
                         self.fig1.show()
@@ -454,15 +454,15 @@ class ErpData(EegData):
 
                     # TODO: Code is currently unreachable
                     else:
-                        logger.error("Insufficient windows to make a decision")
+                        logger.error("Insufficient trials to make a decision")
                         self.decision_count -= 1
                         # logger.info(
-                        #     "Windows per decision: %s",
-                        #     self.windows_per_decision
+                        #     "Trials per decision: %s",
+                        #     self.trials_per_decision
                         # )
 
                     self.decision_count += 1
-                    self.windows_per_decision = np.zeros((self.num_options))
+                    self.trials_per_decision = np.zeros((self.num_options))
 
                     # UPDATE THE SEARCH START LOC
                     # continue
@@ -474,10 +474,10 @@ class ErpData(EegData):
                 self.loops += 1
                 continue
 
-            # Check if the whole EEG window corresponding to the marker is available
+            # Check if the whole EEG trial corresponding to the marker is available
             end_time_plus_buffer = (
                 self.marker_timestamps[self.marker_count]
-                + self.window_end
+                + self.trial_end
                 + self.buffer_time
             )
 
@@ -505,13 +505,13 @@ class ErpData(EegData):
                         self.num_options = int(info)
 
                         # Resize on the first marker
-                        self.windows_per_decision = np.zeros((self.num_options))
+                        self.trials_per_decision = np.zeros((self.num_options))
                 elif i == 3:
                     self.unity_label = int(info)
                 elif i >= 4:
                     flash_indices.append(int(info))
 
-            self.windows_per_decision[flash_indices] += 1
+            self.trials_per_decision[flash_indices] += 1
 
             # During training,
             # should this be repeated for multiple flash indices
@@ -523,24 +523,24 @@ class ErpData(EegData):
                     logger.info("Marker information: %s", current_marker_info)
                     current_target = self.unity_label
 
-                self.training_labels[self.n_windows] = current_target
+                self.training_labels[self.n_trials] = current_target
 
                 for fi in flash_indices:
-                    self.stim_labels[self.n_windows, fi] = True
+                    self.stim_labels[self.n_trials, fi] = True
 
                 if current_target in flash_indices:
-                    self.target_index[self.n_windows] = True
+                    self.target_index[self.n_trials] = True
                 else:
-                    self.target_index[self.n_windows] = False
+                    self.target_index[self.n_trials] = False
 
-            # Find the start time and end time for the window based on the marker timestamp
-            start_time = self.marker_timestamps[self.marker_count] + self.window_start
-            # end_time = self.marker_timestamps[self.marker_count] + self.window_end
+            # Find the start time and end time for the trial based on the marker timestamp
+            start_time = self.marker_timestamps[self.marker_count] + self.trial_start
+            # end_time = self.marker_timestamps[self.marker_count] + self.trial_end
 
-            # locate the indices of the window in the eeg data
+            # locate the indices of the trial in the eeg data
             for i, s in enumerate(self.eeg_timestamps[self.search_index : -1]):
                 logger.debug(
-                    "Indices (i,s) of the window in the eeg data: (%s,%s)", i, s
+                    "Indices (i,s) of the trial in the eeg data: (%s,%s)", i, s
                 )
                 if s > start_time:
                     start_loc = self.search_index + i - 1
@@ -550,10 +550,10 @@ class ErpData(EegData):
                     break
             end_loc = start_loc + self.n_samples + 1
 
-            # Adjust windows per option
-            # self.windows_per_option = np.zeros(self.num_options, dtype=int)
+            # Adjust trials per option
+            # self.trials_per_option = np.zeros(self.num_options, dtype=int)
 
-            logger.debug("Window (start_loc, end_loc): (%s, %s)", start_loc, end_loc)
+            logger.debug("Trial (start_loc, end_loc): (%s, %s)", start_loc, end_loc)
             # linear interpolation and add to numpy array
             for flash_index in flash_indices:
                 for c in range(self.n_channels):
@@ -563,23 +563,23 @@ class ErpData(EegData):
                     )
 
                     channel_data = np.interp(
-                        self.window_timestamps,
+                        self.trial_timestamps,
                         eeg_timestamps_adjusted,
                         self.eeg_data[start_loc:end_loc, c],
                     )
 
-                    # add to raw ERP windows
-                    self.erp_windows_raw[
-                        self.n_windows, c, 0 : self.n_samples
+                    # add to raw ERP trials
+                    self.erp_trials_raw[
+                        self.n_trials, c, 0 : self.n_samples
                     ] = channel_data
-                    # self.decision_blocks_raw[self.decision_count, self.n_windows, c, 0:self.n_samples]
+                    # self.decision_blocks_raw[self.decision_count, self.n_trials, c, 0:self.n_samples]
 
                     # if self.pp_type == "bandpass":
                     #     channel_data_2 = bandpass(channel_data[np.newaxis,:], self.pp_low, self.pp_high, self.pp_order, self.fsample)
                     #     channel_data = channel_data_2[0,:]
 
                     # # Add to the instance count
-                    # self.windows_per_decision[flash_index] += 1
+                    # self.trials_per_decision[flash_index] += 1
 
                     if self.plot_erp:
                         if flash_index == current_target:
@@ -592,18 +592,18 @@ class ErpData(EegData):
                             self.axs2[c].plot(range(self.n_samples), channel_data)
                             self.non_target_plot = flash_index
 
-                    # # add to processed ERP windows
-                    # self.erp_windows[self.n_windows, c, 0:self.n_samples] = channel_data
+                    # # add to processed ERP trials
+                    # self.erp_trials[self.n_trials, c, 0:self.n_samples] = channel_data
 
                     # # Does the ensemble avearging
                     # self.decision_blocks[self.decision_count, flash_index, c, 0:self.n_samples] += channel_data
 
                 # This is where to do preprocessing
-                self.erp_windows_processed[
-                    self.n_windows, : self.n_channels, : self.n_samples
+                self.erp_trials_processed[
+                    self.n_trials, : self.n_channels, : self.n_samples
                 ] = self._preprocessing(
-                    window=self.erp_windows_raw[
-                        self.n_windows, : self.n_channels, : self.n_samples
+                    trial=self.erp_trials_raw[
+                        self.n_trials, : self.n_channels, : self.n_samples
                     ],
                     option=self.pp_type,
                     order=self.pp_order,
@@ -612,43 +612,43 @@ class ErpData(EegData):
                 )
 
                 # This is where to do artefact rejection
-                self.erp_windows_processed[
-                    self.n_windows, : self.n_channels, : self.n_samples
+                self.erp_trials_processed[
+                    self.n_trials, : self.n_channels, : self.n_samples
                 ] = self._artefact_rejection(
-                    window=self.erp_windows_processed[
-                        self.n_windows, : self.n_channels, : self.n_samples
+                    trial=self.erp_trials_processed[
+                        self.n_trials, : self.n_channels, : self.n_samples
                     ],
                     option=None,
                 )
 
-                # Add the raw window to the raw decision blocks
-                # self.decision_blocks_raw[self.decision_count, flash_index, 0:self.n_channels, 0:self.n_samples] +=  self.erp_windows_processed
+                # Add the raw trial to the raw decision blocks
+                # self.decision_blocks_raw[self.decision_count, flash_index, 0:self.n_channels, 0:self.n_samples] +=  self.erp_trials_processed
                 self.big_decision_blocks_raw[
                     self.decision_count,
                     flash_index,
-                    int(self.windows_per_decision[flash_index] - 1),
+                    int(self.trials_per_decision[flash_index] - 1),
                     0 : self.n_channels,
                     0 : self.n_samples,
-                ] = self.erp_windows_raw[
-                    self.n_windows, : self.n_channels, : self.n_samples
+                ] = self.erp_trials_raw[
+                    self.n_trials, : self.n_channels, : self.n_samples
                 ]
 
                 self.big_decision_blocks_processed[
                     self.decision_count,
                     flash_index,
-                    int(self.windows_per_decision[flash_index] - 1),
+                    int(self.trials_per_decision[flash_index] - 1),
                     0 : self.n_channels,
                     0 : self.n_samples,
-                ] = self.erp_windows_processed[
-                    self.n_windows, : self.n_channels, : self.n_samples
+                ] = self.erp_trials_processed[
+                    self.n_trials, : self.n_channels, : self.n_samples
                 ]
 
-                # self.windows_per_decision[flash_index] += 1
+                # self.trials_per_decision[flash_index] += 1
             # Reset for the next decision
 
-            # iterate to next window
+            # iterate to next trial
             self.marker_count += 1
-            self.n_windows += 1
+            self.n_trials += 1
             self.search_index = start_loc
             if self.online:
                 time.sleep(0.000001)

--- a/bci_essentials/erp_data.py
+++ b/bci_essentials/erp_data.py
@@ -148,13 +148,13 @@ class ErpData(EegData):
         # plot settings
         self.plot_erp = plot_erp
         if self.plot_erp:
-            self.fig1, self.axs1 = plt.subplots(self.nchannels)
-            self.fig2, self.axs2 = plt.subplots(self.nchannels)
+            self.fig1, self.axs1 = plt.subplots(self.num_channels)
+            self.fig2, self.axs2 = plt.subplots(self.num_channels)
             self.non_target_plot = 99
 
         # iff this is the first time this function is being called for a given dataset
         self.window_size = self.window_end - self.window_start
-        self.nsamples = int(np.ceil(self.window_size * self.fsample) + 1)
+        self.num_samples = int(np.ceil(self.window_size * self.fsample) + 1)
         self.window_end_buffer = self.buffer_time
         self.num_options = max_num_options
         self.max_windows = max_windows
@@ -163,11 +163,11 @@ class ErpData(EegData):
 
         self.search_index = 0
 
-        self.window_timestamps = np.arange(self.nsamples) / self.fsample
+        self.window_timestamps = np.arange(self.num_samples) / self.fsample
 
         # initialize the numbers of markers, windows, and decision blocks to zero
         self.marker_count = 0
-        self.nwindows = 0
+        self.num_windows = 0
         self.decision_count = 0
 
         self.training_labels = np.zeros((self.max_windows), dtype=int)
@@ -177,10 +177,10 @@ class ErpData(EegData):
         # initialize the data structures in numpy arrays
         # ERP windows
         self.erp_windows_raw = np.zeros(
-            (self.max_windows, self.nchannels, self.nsamples)
+            (self.max_windows, self.num_channels, self.num_samples)
         )
         self.erp_windows_processed = np.zeros(
-            (self.max_windows, self.nchannels, self.nsamples)
+            (self.max_windows, self.num_channels, self.num_samples)
         )
 
         # Windows per decision, ie. the number of times each stimulus has flashed
@@ -188,10 +188,10 @@ class ErpData(EegData):
 
         # Decision blocks are the ensemble averages of all windows collected for each stimulus object
         self.decision_blocks_raw = np.ndarray(
-            (self.max_decisions, self.num_options, self.nchannels, self.nsamples)
+            (self.max_decisions, self.num_options, self.num_channels, self.num_samples)
         )
         self.decision_blocks_processed = np.ndarray(
-            (self.max_decisions, self.num_options, self.nchannels, self.nsamples)
+            (self.max_decisions, self.num_options, self.num_channels, self.num_samples)
         )
 
         # Big decision blocks contain all decisions, all stimulus objects, all windows, all channels, and all samples (they are BIG)
@@ -200,8 +200,8 @@ class ErpData(EegData):
                 self.max_decisions,
                 self.num_options,
                 self.max_windows_per_option,
-                self.nchannels,
-                self.nsamples,
+                self.num_channels,
+                self.num_samples,
             )
         )
         self.big_decision_blocks_processed = np.ndarray(
@@ -209,8 +209,8 @@ class ErpData(EegData):
                 self.max_decisions,
                 self.num_options,
                 self.max_windows_per_option,
-                self.nchannels,
-                self.nsamples,
+                self.num_channels,
+                self.num_samples,
             )
         )
 
@@ -248,30 +248,30 @@ class ErpData(EegData):
 
         # Trim the unused ends of numpy arrays
         if self.training:
-            self.training_labels = self.training_labels[0 : self.nwindows - 1]
-            self.target_index = self.target_index[0 : self.nwindows - 1]
+            self.training_labels = self.training_labels[0 : self.num_windows - 1]
+            self.target_index = self.target_index[0 : self.num_windows - 1]
 
-        # self.erp_windows = self.erp_windows[0:self.nwindows, 0:self.nchannels, 0:self.nsamples]
+        # self.erp_windows = self.erp_windows[0:self.num_windows, 0:self.num_channels, 0:self.num_samples]
         self.erp_windows_raw = self.erp_windows_raw[
-            0 : self.nwindows, 0 : self.nchannels, 0 : self.nsamples
+            0 : self.num_windows, 0 : self.num_channels, 0 : self.num_samples
         ]
-        self.target_index = self.target_index[0 : self.nwindows]
-        self.training_labels = self.training_labels[0 : self.nwindows]
-        self.stim_labels = self.stim_labels[0 : self.nwindows, :]
+        self.target_index = self.target_index[0 : self.num_windows]
+        self.training_labels = self.training_labels[0 : self.num_windows]
+        self.stim_labels = self.stim_labels[0 : self.num_windows, :]
         self.num_options_per_decision = self.num_options_per_decision[
             0 : self.decision_count
         ]
         self.decision_blocks_raw = self.decision_blocks_raw[
-            0 : self.decision_count, :, 0 : self.nchannels, 0 : self.nsamples
+            0 : self.decision_count, :, 0 : self.num_channels, 0 : self.num_samples
         ]
         self.decision_blocks_processed = self.decision_blocks_processed[
-            0 : self.decision_count, :, 0 : self.nchannels, 0 : self.nsamples
+            0 : self.decision_count, :, 0 : self.num_channels, 0 : self.num_samples
         ]
         self.big_decision_blocks_raw = self.big_decision_blocks_raw[
-            0 : self.decision_count, :, :, 0 : self.nchannels, 0 : self.nsamples
+            0 : self.decision_count, :, :, 0 : self.num_channels, 0 : self.num_samples
         ]
         self.big_decision_blocks_processed = self.big_decision_blocks_processed[
-            0 : self.decision_count, :, :, 0 : self.nchannels, 0 : self.nsamples
+            0 : self.decision_count, :, :, 0 : self.num_channels, 0 : self.num_samples
         ]
 
     def step(self):
@@ -345,16 +345,16 @@ class ErpData(EegData):
                             self.decision_count,
                             0 : self.num_options,
                             0:num_ensemble_windows,
-                            0 : self.nchannels,
-                            0 : self.nsamples,
+                            0 : self.num_channels,
+                            0 : self.num_samples,
                         ],
                         axis=1,
                     )
                     self.decision_blocks_raw[
                         self.decision_count,
                         0 : self.num_options,
-                        0 : self.nchannels,
-                        0 : self.nsamples,
+                        0 : self.num_channels,
+                        0 : self.num_samples,
                     ] = ensemble_average_block
 
                     # Processed ensemble average
@@ -363,16 +363,16 @@ class ErpData(EegData):
                             self.decision_count,
                             0 : self.num_options,
                             0:num_ensemble_windows,
-                            0 : self.nchannels,
-                            0 : self.nsamples,
+                            0 : self.num_channels,
+                            0 : self.num_samples,
                         ],
                         axis=1,
                     )
                     self.decision_blocks_processed[
                         self.decision_count,
                         0 : self.num_options,
-                        0 : self.nchannels,
-                        0 : self.nsamples,
+                        0 : self.num_channels,
+                        0 : self.num_samples,
                     ] = ensemble_average_block
 
                     # Reset windows per decision
@@ -523,15 +523,15 @@ class ErpData(EegData):
                     logger.info("Marker information: %s", current_marker_info)
                     current_target = self.unity_label
 
-                self.training_labels[self.nwindows] = current_target
+                self.training_labels[self.num_windows] = current_target
 
                 for fi in flash_indices:
-                    self.stim_labels[self.nwindows, fi] = True
+                    self.stim_labels[self.num_windows, fi] = True
 
                 if current_target in flash_indices:
-                    self.target_index[self.nwindows] = True
+                    self.target_index[self.num_windows] = True
                 else:
-                    self.target_index[self.nwindows] = False
+                    self.target_index[self.num_windows] = False
 
             # Find the start time and end time for the window based on the marker timestamp
             start_time = self.marker_timestamps[self.marker_count] + self.window_start
@@ -548,7 +548,7 @@ class ErpData(EegData):
                     #     start_loc = 0
 
                     break
-            end_loc = start_loc + self.nsamples + 1
+            end_loc = start_loc + self.num_samples + 1
 
             # Adjust windows per option
             # self.windows_per_option = np.zeros(self.num_options, dtype=int)
@@ -556,7 +556,7 @@ class ErpData(EegData):
             logger.debug("Window (start_loc, end_loc): (%s, %s)", start_loc, end_loc)
             # linear interpolation and add to numpy array
             for flash_index in flash_indices:
-                for c in range(self.nchannels):
+                for c in range(self.num_channels):
                     eeg_timestamps_adjusted = (
                         self.eeg_timestamps[start_loc:end_loc]
                         - self.eeg_timestamps[start_loc]
@@ -570,9 +570,9 @@ class ErpData(EegData):
 
                     # add to raw ERP windows
                     self.erp_windows_raw[
-                        self.nwindows, c, 0 : self.nsamples
+                        self.num_windows, c, 0 : self.num_samples
                     ] = channel_data
-                    # self.decision_blocks_raw[self.decision_count, self.nwindows, c, 0:self.nsamples]
+                    # self.decision_blocks_raw[self.decision_count, self.num_windows, c, 0:self.num_samples]
 
                     # if self.pp_type == "bandpass":
                     #     channel_data_2 = bandpass(channel_data[np.newaxis,:], self.pp_low, self.pp_high, self.pp_order, self.fsample)
@@ -583,27 +583,27 @@ class ErpData(EegData):
 
                     if self.plot_erp:
                         if flash_index == current_target:
-                            self.axs1[c].plot(range(self.nsamples), channel_data)
+                            self.axs1[c].plot(range(self.num_samples), channel_data)
 
                         elif (
                             self.non_target_plot == 99
                             or self.non_target_plot == flash_index
                         ):
-                            self.axs2[c].plot(range(self.nsamples), channel_data)
+                            self.axs2[c].plot(range(self.num_samples), channel_data)
                             self.non_target_plot = flash_index
 
                     # # add to processed ERP windows
-                    # self.erp_windows[self.nwindows, c, 0:self.nsamples] = channel_data
+                    # self.erp_windows[self.num_windows, c, 0:self.num_samples] = channel_data
 
                     # # Does the ensemble avearging
-                    # self.decision_blocks[self.decision_count, flash_index, c, 0:self.nsamples] += channel_data
+                    # self.decision_blocks[self.decision_count, flash_index, c, 0:self.num_samples] += channel_data
 
                 # This is where to do preprocessing
                 self.erp_windows_processed[
-                    self.nwindows, : self.nchannels, : self.nsamples
+                    self.num_windows, : self.num_channels, : self.num_samples
                 ] = self._preprocessing(
                     window=self.erp_windows_raw[
-                        self.nwindows, : self.nchannels, : self.nsamples
+                        self.num_windows, : self.num_channels, : self.num_samples
                     ],
                     option=self.pp_type,
                     order=self.pp_order,
@@ -613,34 +613,34 @@ class ErpData(EegData):
 
                 # This is where to do artefact rejection
                 self.erp_windows_processed[
-                    self.nwindows, : self.nchannels, : self.nsamples
+                    self.num_windows, : self.num_channels, : self.num_samples
                 ] = self._artefact_rejection(
                     window=self.erp_windows_processed[
-                        self.nwindows, : self.nchannels, : self.nsamples
+                        self.num_windows, : self.num_channels, : self.num_samples
                     ],
                     option=None,
                 )
 
                 # Add the raw window to the raw decision blocks
-                # self.decision_blocks_raw[self.decision_count, flash_index, 0:self.nchannels, 0:self.nsamples] +=  self.erp_windows_processed
+                # self.decision_blocks_raw[self.decision_count, flash_index, 0:self.num_channels, 0:self.num_samples] +=  self.erp_windows_processed
                 self.big_decision_blocks_raw[
                     self.decision_count,
                     flash_index,
                     int(self.windows_per_decision[flash_index] - 1),
-                    0 : self.nchannels,
-                    0 : self.nsamples,
+                    0 : self.num_channels,
+                    0 : self.num_samples,
                 ] = self.erp_windows_raw[
-                    self.nwindows, : self.nchannels, : self.nsamples
+                    self.num_windows, : self.num_channels, : self.num_samples
                 ]
 
                 self.big_decision_blocks_processed[
                     self.decision_count,
                     flash_index,
                     int(self.windows_per_decision[flash_index] - 1),
-                    0 : self.nchannels,
-                    0 : self.nsamples,
+                    0 : self.num_channels,
+                    0 : self.num_samples,
                 ] = self.erp_windows_processed[
-                    self.nwindows, : self.nchannels, : self.nsamples
+                    self.num_windows, : self.num_channels, : self.num_samples
                 ]
 
                 # self.windows_per_decision[flash_index] += 1
@@ -648,7 +648,7 @@ class ErpData(EegData):
 
             # iterate to next window
             self.marker_count += 1
-            self.nwindows += 1
+            self.num_windows += 1
             self.search_index = start_loc
             if self.online:
                 time.sleep(0.000001)

--- a/bci_essentials/io/lsl_sources.py
+++ b/bci_essentials/io/lsl_sources.py
@@ -72,7 +72,7 @@ class LslEegSource(EegSource):
         return self.__info.nominal_srate()
 
     @property
-    def num_channels(self) -> int:
+    def n_channels(self) -> int:
         return self.__info.channel_count()
 
     @property
@@ -96,7 +96,7 @@ class LslEegSource(EegSource):
     def get_channel_properties(self, property: str) -> list[str]:
         properties = []
         descriptions = self.__info.desc().child("channels").child("channel")
-        for i in range(self.num_channels):
+        for i in range(self.n_channels):
             value = descriptions.child_value(property)
             properties.append(value)
             descriptions = descriptions.next_sibling()

--- a/bci_essentials/io/lsl_sources.py
+++ b/bci_essentials/io/lsl_sources.py
@@ -1,4 +1,4 @@
-from pylsl import StreamInlet, resolve_byprop, FOREVER
+from pylsl import StreamInlet, StreamInfo, resolve_byprop, FOREVER
 
 from .sources import MarkerSource, EegSource
 from ..utils.logger import Logger  # Logger wrapper
@@ -11,20 +11,22 @@ __all__ = ["LslMarkerSource", "LslEegSource"]
 
 
 class LslMarkerSource(MarkerSource):
-    def __init__(self, timeout: float = FOREVER):
+    def __init__(self, stream: StreamInfo = None, timeout: float = FOREVER):
         """Create a MarkerSource object that obtains markers from an LSL outlet
 
         Parameters
         ----------
+        stream : StreamInfo, *optional*
+            Provide stream to use for Markers, if not provided, stream will be discovered.
+
         timeout : float, *optional*
             How long to wait for marker outlet stream to be discovered.  If no stream
             is discovered, an Exception is raised.  By default init will wait forever.
         """
         try:
-            marker_stream = resolve_byprop(
-                "type", "LSL_Marker_Strings", timeout=timeout
-            )
-            self.__inlet = StreamInlet(marker_stream[0], processing_flags=0)
+            if stream is None:
+                stream = discover_first_stream("LSL_Marker_Strings", timeout=timeout)
+            self.__inlet = StreamInlet(stream, processing_flags=0)
             self.__info = self.__inlet.info()
         except Exception:
             raise Exception("LslMarkerSource: could not create inlet")
@@ -41,18 +43,22 @@ class LslMarkerSource(MarkerSource):
 
 
 class LslEegSource(EegSource):
-    def __init__(self, timeout: float = FOREVER):
+    def __init__(self, stream: StreamInfo = None, timeout: float = FOREVER):
         """Create a MarkerSource object that obtains EEG from an LSL outlet
 
         Parameters
         ----------
+        stream : StreamInfo, *optional*
+            Provide stream to use for EEG, if not provided, stream will be discovered.
+
         timeout : float, *optional*
-            How long to wait for marker outlet stream to be discovered.  If no stream
-            is discovered, an Exception is raised.  By defalut init will wait forever.
+            How long to wait for marker stream to be discovered.  If no stream is
+            discovered, an Exception is raised.  By defalut init will wait forever.
         """
         try:
-            eeg_stream = resolve_byprop("type", "EEG", timeout=timeout)
-            self.__inlet = StreamInlet(eeg_stream[0], processing_flags=0)
+            if stream is None:
+                stream = discover_first_stream("EEG", timeout=timeout)
+            self.__inlet = StreamInlet(stream, processing_flags=0)
             self.__info = self.__inlet.info()
         except Exception:
             raise Exception("LslEegSource: could not create inlet")
@@ -66,7 +72,7 @@ class LslEegSource(EegSource):
         return self.__info.nominal_srate()
 
     @property
-    def nchannels(self) -> int:
+    def num_channels(self) -> int:
         return self.__info.channel_count()
 
     @property
@@ -90,11 +96,18 @@ class LslEegSource(EegSource):
     def __get_channel_properties(self, property: str) -> list[str]:
         properties = []
         descriptions = self.__info.desc().child("channels").child("channel")
-        for i in range(self.nchannels):
+        for i in range(self.num_channels):
             value = descriptions.child_value(property)
             properties.append(value)
             descriptions = descriptions.next_sibling()
         return properties
+
+
+def discover_first_stream(type: str, timeout: float = FOREVER) -> StreamInfo:
+    """This helper returns the first stream of the specified type.  If no stream
+    is found, an exception is raised."""
+    streams = resolve_byprop("type", type, timeout=timeout)
+    return streams[0]
 
 
 def pull_from_lsl_inlet(inlet: StreamInlet) -> tuple[list[list], list]:

--- a/bci_essentials/io/sources.py
+++ b/bci_essentials/io/sources.py
@@ -68,7 +68,7 @@ class EegSource(ABC):
 
     @property
     @abstractmethod
-    def nchannels(self) -> int:
+    def num_channels(self) -> int:
         """Number of EEG channels per sample"""
         pass
 

--- a/bci_essentials/io/sources.py
+++ b/bci_essentials/io/sources.py
@@ -68,7 +68,7 @@ class EegSource(ABC):
 
     @property
     @abstractmethod
-    def num_channels(self) -> int:
+    def n_channels(self) -> int:
         """Number of EEG channels per sample"""
         pass
 

--- a/bci_essentials/io/sources.py
+++ b/bci_essentials/io/sources.py
@@ -28,7 +28,7 @@ class MarkerSource(ABC):
             Each sample is a list with a single string element that represents a command or
             a marker.  The string is formatted as follows:
             command = an arbitrary string, ex: "Trial Started".
-            marker = "paradigm, num options, label number, window length"
+            marker = "paradigm, num options, label number, trial length"
 
             timestamps - A list timestamps (float in seconds) corresponding to the markers
         """

--- a/bci_essentials/io/xdf_sources.py
+++ b/bci_essentials/io/xdf_sources.py
@@ -70,7 +70,7 @@ class XdfEegSource(EegSource):
         return float(self.__info["nominal_srate"][0])
 
     @property
-    def num_channels(self) -> int:
+    def n_channels(self) -> int:
         return int(self.__info["channel_count"][0])
 
     @property

--- a/bci_essentials/io/xdf_sources.py
+++ b/bci_essentials/io/xdf_sources.py
@@ -70,7 +70,7 @@ class XdfEegSource(EegSource):
         return float(self.__info["nominal_srate"][0])
 
     @property
-    def nchannels(self) -> int:
+    def num_channels(self) -> int:
         return int(self.__info["channel_count"][0])
 
     @property

--- a/bci_essentials/resting_state.py
+++ b/bci_essentials/resting_state.py
@@ -226,7 +226,9 @@ def get_bandpower_features(data, fs, transition_freqs=[0, 4, 8, 12, 30]):
     # Initialize
     abs_bandpower = np.zeros((len(transition_freqs), W_windows))
     rel_bandpower = np.zeros((len(transition_freqs), W_windows))
-    rel_bandpower_mat = np.zeros((len(transition_freqs), len(transition_freqs), W_windows))
+    rel_bandpower_mat = np.zeros(
+        (len(transition_freqs), len(transition_freqs), W_windows)
+    )
 
     # for each window
     for win in range(W_windows):

--- a/bci_essentials/resting_state.py
+++ b/bci_essentials/resting_state.py
@@ -6,8 +6,8 @@ a set of windows.
 - For single windows, inputs are of the shape `n_channels x n_samples`, where:
     - n_channels = number of channels
     - n_samples = number of samples
-- For multiple windows, inputs are of the shape `num_windows x n_channels x n_samples`, where:
-    - num_windows = number of windows
+- For multiple windows, inputs are of the shape `n_windows x n_channels x n_samples`, where:
+    - n_windows = number of windows
     - n_channels = number of channels
     - n_samples = number of samples
 
@@ -35,11 +35,11 @@ def get_shape(data):
         2D or 3D array containing data with `float` type.
 
         shape = (`n_channels`,`n_samples`) OR
-        (`num_windows`,`n_channels`,`n_samples`)
+        (`n_windows`,`n_channels`,`n_samples`)
 
     Returns
     -------
-    num_windows : int
+    n_windows : int
         Number of windows.
     n_channels : int
         Number of channels.
@@ -48,12 +48,12 @@ def get_shape(data):
 
     """
     try:
-        num_windows, n_channels, n_samples = np.shape(data)
+        n_windows, n_channels, n_samples = np.shape(data)
     except Exception:
         n_channels, n_samples = np.shape(data)
-        num_windows = 1
+        n_windows = 1
 
-    return num_windows, n_channels, n_samples
+    return n_windows, n_channels, n_samples
 
 
 # This function is never used at the moment, anywhere in the code. Renaming to more clear convention on it being a public function.
@@ -119,7 +119,7 @@ def get_alpha_peak(data, alpha_min=8, alpha_max=12, plot_psd=False):
         Resting state EEG window with eyes closed.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`n_channels`,`n_samples`)
+        shape = (`n_windows`,`n_channels`,`n_samples`)
     alpha_min : float, *optional*
         Lowest possible value of alpha peak (Hz)
         - Default is `8`.
@@ -138,12 +138,12 @@ def get_alpha_peak(data, alpha_min=8, alpha_max=12, plot_psd=False):
 
     fs = 256
 
-    num_windows, n_channels, n_samples = get_shape(data)
+    n_windows, n_channels, n_samples = get_shape(data)
 
-    # Create alpha_peaks of length num_windows
-    alpha_peaks = np.zeros(num_windows)
+    # Create alpha_peaks of length n_windows
+    alpha_peaks = np.zeros(n_windows)
 
-    for window in range(num_windows):
+    for window in range(n_windows):
         # Get the current window
         current_window = data[window, :, :]
 
@@ -192,7 +192,7 @@ def get_bandpower_features(data, fs, transition_freqs=[0, 4, 8, 12, 30]):
         Windows of resting state EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_windows`,`n_channels`,`n_samples`)
+        shape = (`n_windows`,`n_channels`,`n_samples`)
     fs : float
         Sampling frequency (Hz).
     transition_freqs : array-like, *optional*
@@ -221,17 +221,17 @@ def get_bandpower_features(data, fs, transition_freqs=[0, 4, 8, 12, 30]):
 
     """
     # Get Shape
-    num_windows, n_channels, n_samples = get_shape(data)
+    n_windows, n_channels, n_samples = get_shape(data)
 
     # Initialize
-    abs_bandpower = np.zeros((len(transition_freqs), num_windows))
-    rel_bandpower = np.zeros((len(transition_freqs), num_windows))
+    abs_bandpower = np.zeros((len(transition_freqs), n_windows))
+    rel_bandpower = np.zeros((len(transition_freqs), n_windows))
     rel_bandpower_mat = np.zeros(
-        (len(transition_freqs), len(transition_freqs), num_windows)
+        (len(transition_freqs), len(transition_freqs), n_windows)
     )
 
     # for each window
-    for window in range(num_windows):
+    for window in range(n_windows):
         # Get the current window
         current_window = data[window, :, :]
 

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -2,13 +2,13 @@
 Signal processing tools for processing windows of EEG data.
 
 The EEG data inputs can be 2D or 3D arrays.
-- For single windows, inputs are of the shape `num_channels x num_samples`, where:
-    - num_channels = number of channels
-    - num_samples = number of samples
-- For multiple windows, inputs are of the shape `num_windows x num_channels x num_samples`, where:
+- For single windows, inputs are of the shape `n_channels x n_samples`, where:
+    - n_channels = number of channels
+    - n_samples = number of samples
+- For multiple windows, inputs are of the shape `num_windows x n_channels x n_samples`, where:
     - num_windows = number of windows
-    - num_channels = number of channels
-    - num_samples = number of samples
+    - n_channels = number of channels
+    - n_samples = number of samples
 
 - Outputs are the same dimensions as input (windows, channels, samples)
 
@@ -37,7 +37,7 @@ def bandpass(data, f_low, f_high, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
+        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
     f_low : float
         Lower corner frequency.
     f_high : float
@@ -53,16 +53,16 @@ def bandpass(data, f_low, f_high, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
+        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = [f_low / (fsample / 2), f_high / (fsample / 2)]
     b, a = signal.butter(order, Wn, btype="bandpass")
 
     try:
-        num_windows, num_channels, num_samples = np.shape(data)
+        num_windows, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(num_windows, num_channels, num_samples), dtype=float
+            shape=(num_windows, n_channels, n_samples), dtype=float
         )
         for window in range(0, num_windows):
             current_window = data[window, :, :]
@@ -71,9 +71,9 @@ def bandpass(data, f_low, f_high, order, fsample):
         return new_data
 
     except ValueError:
-        num_channels, num_samples = np.shape(data)
+        n_channels, n_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(num_channels, num_samples), dtype=float)
+        new_data = np.ndarray(shape=(n_channels, n_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -92,7 +92,7 @@ def lowpass(data, f_critical, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
+        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -106,19 +106,19 @@ def lowpass(data, f_critical, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
+        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="lowpass")
 
     try:
-        num_windows, num_channels, num_samples = np.shape(data)
+        num_windows, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(num_windows, num_channels, num_samples), dtype=float
+            shape=(num_windows, n_channels, n_samples), dtype=float
         )
         for window in range(0, num_windows):
-            for channel in range(0, num_channels):
+            for channel in range(0, n_channels):
                 current_window = data[window, channel, :]
                 new_data[window, channel, :] = signal.filtfilt(
                     b, a, current_window, padlen=0
@@ -127,9 +127,9 @@ def lowpass(data, f_critical, order, fsample):
         return new_data
 
     except ValueError:
-        num_channels, num_samples = np.shape(data)
+        n_channels, n_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(num_channels, num_samples), dtype=float)
+        new_data = np.ndarray(shape=(n_channels, n_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -148,7 +148,7 @@ def highpass(data, f_critical, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
+        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -162,16 +162,16 @@ def highpass(data, f_critical, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
+        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="highpass")
 
     try:
-        num_windows, num_channels, num_samples = np.shape(data)
+        num_windows, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(num_windows, num_channels, num_samples), dtype=float
+            shape=(num_windows, n_channels, n_samples), dtype=float
         )
         for window in range(0, num_windows):
             current_window = data[window, :, :]
@@ -180,9 +180,9 @@ def highpass(data, f_critical, order, fsample):
         return new_data
 
     except ValueError:
-        num_channels, num_samples = np.shape(data)
+        n_channels, n_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(num_channels, num_samples), dtype=float)
+        new_data = np.ndarray(shape=(n_channels, n_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -199,7 +199,7 @@ def notch(data, f_notch, Q, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
+        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
     f_notch : float
         Frequency of notch.
     Q : float
@@ -222,9 +222,9 @@ def notch(data, f_notch, Q, fsample):
     b, a = signal.iirnotch(f_notch, Q, fsample)
 
     try:
-        num_windows, num_channels, num_samples = np.shape(data)
+        num_windows, n_channels, n_samples = np.shape(data)
         new_data = np.ndarray(
-            shape=(num_windows, num_channels, num_samples), dtype=float
+            shape=(num_windows, n_channels, n_samples), dtype=float
         )
         for window in range(0, num_windows):
             current_window = data[window, :, :]
@@ -232,8 +232,8 @@ def notch(data, f_notch, Q, fsample):
         return new_data
 
     except Exception:
-        num_channels, num_samples = np.shape(data)
-        new_data = np.ndarray(shape=(num_channels, num_samples), dtype=float)
+        n_channels, n_samples = np.shape(data)
+        new_data = np.ndarray(shape=(n_channels, n_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
         return new_data
 
@@ -251,7 +251,7 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
         Windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (num_windows, num_channels, num_samples)
+        shape = (num_windows, n_channels, n_samples)
     y : numpy.ndarray
         Labels corresponding to X.
     expansion_factor : int, *optional*
@@ -271,10 +271,10 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
     """
     true_X = X[y == 1]
 
-    num_windows, num_channels, num_samples = true_X.shape
+    num_windows, n_channels, n_samples = true_X.shape
     logger.info("Shape of ERPs only: %s", true_X.shape)
     new_window = num_windows * np.round(expansion_factor - 1)
-    new_X = np.zeros([new_window, num_channels, num_samples])
+    new_X = np.zeros([new_window, n_channels, n_samples])
     for window in range(num_windows):
         for j in range(sum_num):
             random_epoch = true_X[random.choice(range(num_windows)), :, :]

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -209,7 +209,7 @@ def notch(data, f_notch, Q, fsample):
         Trials of filtered EEG data.
         3D array containing data with `float` type.
 
-        shape = (`N_trials`,`M_channels`,`P_samples`)
+        shape = (`n_trials`,`n_channels`,`n_samples`)
 
     """
 

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -1,7 +1,7 @@
 """
 Signal processing tools for processing windows of EEG data.
 
-The EEG data inputs can be 2D or 3D arrays. 
+The EEG data inputs can be 2D or 3D arrays.
 - For single windows, inputs are of the shape `C_channels x S_samples`, where:
     - C_channels = number of channels
     - S_samples = number of samples

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -1,16 +1,16 @@
 """
-Signal processing tools for processing windows of EEG data.
+Signal processing tools for processing trials of EEG data.
 
 The EEG data inputs can be 2D or 3D arrays.
-- For single windows, inputs are of the shape `n_channels x n_samples`, where:
+- For single trials, inputs are of the shape `n_channels x n_samples`, where:
     - n_channels = number of channels
     - n_samples = number of samples
-- For multiple windows, inputs are of the shape `n_windows x n_channels x n_samples`, where:
-    - n_windows = number of windows
+- For multiple trials, inputs are of the shape `n_trials x n_channels x n_samples`, where:
+    - n_trials = number of trials
     - n_channels = number of channels
     - n_samples = number of samples
 
-- Outputs are the same dimensions as input (windows, channels, samples)
+- Outputs are the same dimensions as input (trials, channels, samples)
 
 """
 import numpy as np
@@ -34,10 +34,10 @@ def bandpass(data, f_low, f_high, order, fsample):
     Parameters
     ----------
     data : numpy.ndarray
-        Windows of EEG data.
+        Trials of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     f_low : float
         Lower corner frequency.
     f_high : float
@@ -50,23 +50,23 @@ def bandpass(data, f_low, f_high, order, fsample):
     Returns
     -------
     new_data : numpy.ndarray
-        Windows of filtered EEG data.
+        Trials of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = [f_low / (fsample / 2), f_high / (fsample / 2)]
     b, a = signal.butter(order, Wn, btype="bandpass")
 
     try:
-        n_windows, n_channels, n_samples = np.shape(data)
+        n_trials, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(n_windows, n_channels, n_samples), dtype=float
+            shape=(n_trials, n_channels, n_samples), dtype=float
         )
-        for window in range(0, n_windows):
-            current_window = data[window, :, :]
-            new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        for trial in range(0, n_trials):
+            current_trial = data[trial, :, :]
+            new_data[trial, :, :] = signal.filtfilt(b, a, current_trial, padlen=0)
 
         return new_data
 
@@ -89,10 +89,10 @@ def lowpass(data, f_critical, order, fsample):
     Parameters
     ----------
     data : numpy.ndarray
-        Windows of EEG data.
+        Trials of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -103,25 +103,25 @@ def lowpass(data, f_critical, order, fsample):
     Returns
     -------
     new_data : numpy.ndarray
-        Windows of filtered EEG data.
+        Trials of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="lowpass")
 
     try:
-        n_windows, n_channels, n_samples = np.shape(data)
+        n_trials, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(n_windows, n_channels, n_samples), dtype=float
+            shape=(n_trials, n_channels, n_samples), dtype=float
         )
-        for window in range(0, n_windows):
+        for trial in range(0, n_trials):
             for channel in range(0, n_channels):
-                current_window = data[window, channel, :]
-                new_data[window, channel, :] = signal.filtfilt(
-                    b, a, current_window, padlen=0
+                current_trial = data[trial, channel, :]
+                new_data[trial, channel, :] = signal.filtfilt(
+                    b, a, current_trial, padlen=0
                 )
 
         return new_data
@@ -145,10 +145,10 @@ def highpass(data, f_critical, order, fsample):
     Parameters
     ----------
     data : numpy.ndarray
-        Windows of EEG data.
+        Trials of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -159,23 +159,23 @@ def highpass(data, f_critical, order, fsample):
     Returns
     -------
     new_data : numpy.ndarray
-        Windows of filtered EEG data.
+        Trials of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="highpass")
 
     try:
-        n_windows, n_channels, n_samples = np.shape(data)
+        n_trials, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(n_windows, n_channels, n_samples), dtype=float
+            shape=(n_trials, n_channels, n_samples), dtype=float
         )
-        for window in range(0, n_windows):
-            current_window = data[window, :, :]
-            new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        for trial in range(0, n_trials):
+            current_trial = data[trial, :, :]
+            new_data[trial, :, :] = signal.filtfilt(b, a, current_trial, padlen=0)
 
         return new_data
 
@@ -196,10 +196,10 @@ def notch(data, f_notch, Q, fsample):
     Parameters
     ----------
     data : numpy.ndarray
-        Windows of EEG data.
+        Trials of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     f_notch : float
         Frequency of notch.
     Q : float
@@ -212,23 +212,23 @@ def notch(data, f_notch, Q, fsample):
     Returns
     -------
     new_data : numpy.ndarray
-        Windows of filtered EEG data.
+        Trials of filtered EEG data.
         3D array containing data with `float` type.
 
-        shape = (`N_windows`,`M_channels`,`P_samples`)
+        shape = (`N_trials`,`M_channels`,`P_samples`)
 
     """
 
     b, a = signal.iirnotch(f_notch, Q, fsample)
 
     try:
-        n_windows, n_channels, n_samples = np.shape(data)
+        n_trials, n_channels, n_samples = np.shape(data)
         new_data = np.ndarray(
-            shape=(n_windows, n_channels, n_samples), dtype=float
+            shape=(n_trials, n_channels, n_samples), dtype=float
         )
-        for window in range(0, n_windows):
-            current_window = data[window, :, :]
-            new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        for trial in range(0, n_trials):
+            current_trial = data[trial, :, :]
+            new_data[trial, :, :] = signal.filtfilt(b, a, current_trial, padlen=0)
         return new_data
 
     except Exception:
@@ -248,10 +248,10 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
     Parameters
     ----------
     X : numpy.ndarray
-        Windows of EEG data.
+        Trials of EEG data.
         3D array containing data with `float` type.
 
-        shape = (n_windows, n_channels, n_samples)
+        shape = (n_trials, n_channels, n_samples)
     y : numpy.ndarray
         Labels corresponding to X.
     expansion_factor : int, *optional*
@@ -271,16 +271,16 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
     """
     true_X = X[y == 1]
 
-    n_windows, n_channels, n_samples = true_X.shape
+    n_trials, n_channels, n_samples = true_X.shape
     logger.info("Shape of ERPs only: %s", true_X.shape)
-    new_window = n_windows * np.round(expansion_factor - 1)
-    new_X = np.zeros([new_window, n_channels, n_samples])
-    for window in range(n_windows):
+    new_trial = n_trials * np.round(expansion_factor - 1)
+    new_X = np.zeros([new_trial, n_channels, n_samples])
+    for trial in range(n_trials):
         for j in range(sum_num):
-            random_epoch = true_X[random.choice(range(n_windows)), :, :]
-            new_X[window, :, :] += random_epoch / sum_num
+            random_epoch = true_X[random.choice(range(n_trials)), :, :]
+            new_X[trial, :, :] += random_epoch / sum_num
 
     over_X = np.append(X, new_X, axis=0)
-    over_y = np.append(y, np.ones([new_window]))
+    over_y = np.append(y, np.ones([new_trial]))
 
     return over_X, over_y

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -61,9 +61,7 @@ def bandpass(data, f_low, f_high, order, fsample):
     try:
         n_trials, n_channels, n_samples = np.shape(data)
 
-        new_data = np.ndarray(
-            shape=(n_trials, n_channels, n_samples), dtype=float
-        )
+        new_data = np.ndarray(shape=(n_trials, n_channels, n_samples), dtype=float)
         for trial in range(0, n_trials):
             current_trial = data[trial, :, :]
             new_data[trial, :, :] = signal.filtfilt(b, a, current_trial, padlen=0)
@@ -114,9 +112,7 @@ def lowpass(data, f_critical, order, fsample):
     try:
         n_trials, n_channels, n_samples = np.shape(data)
 
-        new_data = np.ndarray(
-            shape=(n_trials, n_channels, n_samples), dtype=float
-        )
+        new_data = np.ndarray(shape=(n_trials, n_channels, n_samples), dtype=float)
         for trial in range(0, n_trials):
             for channel in range(0, n_channels):
                 current_trial = data[trial, channel, :]
@@ -170,9 +166,7 @@ def highpass(data, f_critical, order, fsample):
     try:
         n_trials, n_channels, n_samples = np.shape(data)
 
-        new_data = np.ndarray(
-            shape=(n_trials, n_channels, n_samples), dtype=float
-        )
+        new_data = np.ndarray(shape=(n_trials, n_channels, n_samples), dtype=float)
         for trial in range(0, n_trials):
             current_trial = data[trial, :, :]
             new_data[trial, :, :] = signal.filtfilt(b, a, current_trial, padlen=0)
@@ -223,9 +217,7 @@ def notch(data, f_notch, Q, fsample):
 
     try:
         n_trials, n_channels, n_samples = np.shape(data)
-        new_data = np.ndarray(
-            shape=(n_trials, n_channels, n_samples), dtype=float
-        )
+        new_data = np.ndarray(shape=(n_trials, n_channels, n_samples), dtype=float)
         for trial in range(0, n_trials):
             current_trial = data[trial, :, :]
             new_data[trial, :, :] = signal.filtfilt(b, a, current_trial, padlen=0)

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -5,8 +5,8 @@ The EEG data inputs can be 2D or 3D arrays.
 - For single windows, inputs are of the shape `n_channels x n_samples`, where:
     - n_channels = number of channels
     - n_samples = number of samples
-- For multiple windows, inputs are of the shape `num_windows x n_channels x n_samples`, where:
-    - num_windows = number of windows
+- For multiple windows, inputs are of the shape `n_windows x n_channels x n_samples`, where:
+    - n_windows = number of windows
     - n_channels = number of channels
     - n_samples = number of samples
 
@@ -37,7 +37,7 @@ def bandpass(data, f_low, f_high, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
     f_low : float
         Lower corner frequency.
     f_high : float
@@ -53,18 +53,18 @@ def bandpass(data, f_low, f_high, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = [f_low / (fsample / 2), f_high / (fsample / 2)]
     b, a = signal.butter(order, Wn, btype="bandpass")
 
     try:
-        num_windows, n_channels, n_samples = np.shape(data)
+        n_windows, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(num_windows, n_channels, n_samples), dtype=float
+            shape=(n_windows, n_channels, n_samples), dtype=float
         )
-        for window in range(0, num_windows):
+        for window in range(0, n_windows):
             current_window = data[window, :, :]
             new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
 
@@ -92,7 +92,7 @@ def lowpass(data, f_critical, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -106,18 +106,18 @@ def lowpass(data, f_critical, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="lowpass")
 
     try:
-        num_windows, n_channels, n_samples = np.shape(data)
+        n_windows, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(num_windows, n_channels, n_samples), dtype=float
+            shape=(n_windows, n_channels, n_samples), dtype=float
         )
-        for window in range(0, num_windows):
+        for window in range(0, n_windows):
             for channel in range(0, n_channels):
                 current_window = data[window, channel, :]
                 new_data[window, channel, :] = signal.filtfilt(
@@ -148,7 +148,7 @@ def highpass(data, f_critical, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -162,18 +162,18 @@ def highpass(data, f_critical, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="highpass")
 
     try:
-        num_windows, n_channels, n_samples = np.shape(data)
+        n_windows, n_channels, n_samples = np.shape(data)
 
         new_data = np.ndarray(
-            shape=(num_windows, n_channels, n_samples), dtype=float
+            shape=(n_windows, n_channels, n_samples), dtype=float
         )
-        for window in range(0, num_windows):
+        for window in range(0, n_windows):
             current_window = data[window, :, :]
             new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
 
@@ -199,7 +199,7 @@ def notch(data, f_notch, Q, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (num_windows, n_channels, n_samples) or (n_channels, n_samples)
+        shape = (n_windows, n_channels, n_samples) or (n_channels, n_samples)
     f_notch : float
         Frequency of notch.
     Q : float
@@ -222,11 +222,11 @@ def notch(data, f_notch, Q, fsample):
     b, a = signal.iirnotch(f_notch, Q, fsample)
 
     try:
-        num_windows, n_channels, n_samples = np.shape(data)
+        n_windows, n_channels, n_samples = np.shape(data)
         new_data = np.ndarray(
-            shape=(num_windows, n_channels, n_samples), dtype=float
+            shape=(n_windows, n_channels, n_samples), dtype=float
         )
-        for window in range(0, num_windows):
+        for window in range(0, n_windows):
             current_window = data[window, :, :]
             new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
         return new_data
@@ -251,7 +251,7 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
         Windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (num_windows, n_channels, n_samples)
+        shape = (n_windows, n_channels, n_samples)
     y : numpy.ndarray
         Labels corresponding to X.
     expansion_factor : int, *optional*
@@ -271,13 +271,13 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
     """
     true_X = X[y == 1]
 
-    num_windows, n_channels, n_samples = true_X.shape
+    n_windows, n_channels, n_samples = true_X.shape
     logger.info("Shape of ERPs only: %s", true_X.shape)
-    new_window = num_windows * np.round(expansion_factor - 1)
+    new_window = n_windows * np.round(expansion_factor - 1)
     new_X = np.zeros([new_window, n_channels, n_samples])
-    for window in range(num_windows):
+    for window in range(n_windows):
         for j in range(sum_num):
-            random_epoch = true_X[random.choice(range(num_windows)), :, :]
+            random_epoch = true_X[random.choice(range(n_windows)), :, :]
             new_X[window, :, :] += random_epoch / sum_num
 
     over_X = np.append(X, new_X, axis=0)

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -2,13 +2,13 @@
 Signal processing tools for processing windows of EEG data.
 
 The EEG data inputs can be 2D or 3D arrays.
-- For single windows, inputs are of the shape `C_channels x S_samples`, where:
-    - C_channels = number of channels
-    - S_samples = number of samples
-- For multiple windows, inputs are of the shape `W_windows x C_channels x S_samples`, where:
-    - W_windows = number of windows
-    - C_channels = number of channels
-    - S_samples = number of samples
+- For single windows, inputs are of the shape `num_channels x num_samples`, where:
+    - num_channels = number of channels
+    - num_samples = number of samples
+- For multiple windows, inputs are of the shape `num_windows x num_channels x num_samples`, where:
+    - num_windows = number of windows
+    - num_channels = number of channels
+    - num_samples = number of samples
 
 - Outputs are the same dimensions as input (windows, channels, samples)
 
@@ -37,7 +37,7 @@ def bandpass(data, f_low, f_high, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
+        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
     f_low : float
         Lower corner frequency.
     f_high : float
@@ -53,25 +53,27 @@ def bandpass(data, f_low, f_high, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
+        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
     """
     Wn = [f_low / (fsample / 2), f_high / (fsample / 2)]
     b, a = signal.butter(order, Wn, btype="bandpass")
 
     try:
-        W_windows, C_channels, S_samples = np.shape(data)
+        num_windows, num_channels, num_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(W_windows, C_channels, S_samples), dtype=float)
-        for W in range(0, W_windows):
-            current_window = data[W, :, :]
-            new_data[W, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        new_data = np.ndarray(
+            shape=(num_windows, num_channels, num_samples), dtype=float
+        )
+        for window in range(0, num_windows):
+            current_window = data[window, :, :]
+            new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
 
         return new_data
 
     except ValueError:
-        C_channels, S_samples = np.shape(data)
+        num_channels, num_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(C_channels, S_samples), dtype=float)
+        new_data = np.ndarray(shape=(num_channels, num_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -90,7 +92,7 @@ def lowpass(data, f_critical, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
+        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -104,26 +106,30 @@ def lowpass(data, f_critical, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
+        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="lowpass")
 
     try:
-        W_windows, C_channels, S_samples = np.shape(data)
+        num_windows, num_channels, num_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(W_windows, C_channels, S_samples), dtype=float)
-        for W in range(0, W_windows):
-            for C in range(0, C_channels):
-                current_window = data[W, C, :]
-                new_data[W, C, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        new_data = np.ndarray(
+            shape=(num_windows, num_channels, num_samples), dtype=float
+        )
+        for window in range(0, num_windows):
+            for channel in range(0, num_channels):
+                current_window = data[window, channel, :]
+                new_data[window, channel, :] = signal.filtfilt(
+                    b, a, current_window, padlen=0
+                )
 
         return new_data
 
     except ValueError:
-        C_channels, S_samples = np.shape(data)
+        num_channels, num_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(C_channels, S_samples), dtype=float)
+        new_data = np.ndarray(shape=(num_channels, num_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -142,7 +148,7 @@ def highpass(data, f_critical, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
+        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -156,25 +162,27 @@ def highpass(data, f_critical, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
+        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="highpass")
 
     try:
-        W_windows, C_channels, S_samples = np.shape(data)
+        num_windows, num_channels, num_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(W_windows, C_channels, S_samples), dtype=float)
-        for W in range(0, W_windows):
-            current_window = data[W, :, :]
-            new_data[W, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        new_data = np.ndarray(
+            shape=(num_windows, num_channels, num_samples), dtype=float
+        )
+        for window in range(0, num_windows):
+            current_window = data[window, :, :]
+            new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
 
         return new_data
 
     except ValueError:
-        C_channels, S_samples = np.shape(data)
+        num_channels, num_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(C_channels, S_samples), dtype=float)
+        new_data = np.ndarray(shape=(num_channels, num_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -191,7 +199,7 @@ def notch(data, f_notch, Q, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
+        shape = (num_windows, num_channels, num_samples) or (num_channels, num_samples)
     f_notch : float
         Frequency of notch.
     Q : float
@@ -214,16 +222,18 @@ def notch(data, f_notch, Q, fsample):
     b, a = signal.iirnotch(f_notch, Q, fsample)
 
     try:
-        W_windows, C_channels, S_samples = np.shape(data)
-        new_data = np.ndarray(shape=(W_windows, C_channels, S_samples), dtype=float)
-        for W in range(0, W_windows):
-            current_window = data[W, :, :]
-            new_data[W, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        num_windows, num_channels, num_samples = np.shape(data)
+        new_data = np.ndarray(
+            shape=(num_windows, num_channels, num_samples), dtype=float
+        )
+        for window in range(0, num_windows):
+            current_window = data[window, :, :]
+            new_data[window, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
         return new_data
 
     except Exception:
-        C_channels, S_samples = np.shape(data)
-        new_data = np.ndarray(shape=(C_channels, S_samples), dtype=float)
+        num_channels, num_samples = np.shape(data)
+        new_data = np.ndarray(shape=(num_channels, num_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
         return new_data
 
@@ -241,7 +251,7 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
         Windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (W_windows, C_channels, S_samples)
+        shape = (num_windows, num_channels, num_samples)
     y : numpy.ndarray
         Labels corresponding to X.
     expansion_factor : int, *optional*
@@ -261,16 +271,16 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
     """
     true_X = X[y == 1]
 
-    W_windows, C_channels, S_samples = true_X.shape
+    num_windows, num_channels, num_samples = true_X.shape
     logger.info("Shape of ERPs only: %s", true_X.shape)
-    new_W = W_windows * np.round(expansion_factor - 1)
-    new_X = np.zeros([new_W, C_channels, S_samples])
-    for W in range(W_windows):
+    new_window = num_windows * np.round(expansion_factor - 1)
+    new_X = np.zeros([new_window, num_channels, num_samples])
+    for window in range(num_windows):
         for j in range(sum_num):
-            random_epoch = true_X[random.choice(range(W_windows)), :, :]
-            new_X[W, :, :] += random_epoch / sum_num
+            random_epoch = true_X[random.choice(range(num_windows)), :, :]
+            new_X[window, :, :] += random_epoch / sum_num
 
     over_X = np.append(X, new_X, axis=0)
-    over_y = np.append(y, np.ones([new_W]))
+    over_y = np.append(y, np.ones([new_window]))
 
     return over_X, over_y

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -1,12 +1,16 @@
 """
 Signal processing tools for processing windows of EEG data.
 
-The EEG data inputs can be 2D or 3D arrays. Either 'N x M' or 'P x N x M', where:
-    - P = number of windows (for a single window `N = 1`)
-    - N = number of channels
-    - M = number of samples
+The EEG data inputs can be 2D or 3D arrays. 
+- For single windows, inputs are of the shape `C_channels x S_samples`, where:
+    - C_channels = number of channels
+    - S_samples = number of samples
+- For multiple windows, inputs are of the shape `W_windows x C_channels x S_samples`, where:
+    - W_windows = number of windows
+    - C_channels = number of channels
+    - S_samples = number of samples
 
-- Outputs are the same dimensions (`P x N x M`)
+- Outputs are the same dimensions as input (windows, channels, samples)
 
 """
 import numpy as np
@@ -33,7 +37,7 @@ def bandpass(data, f_low, f_high, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (P, N, M) or (N, M)
+        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
     f_low : float
         Lower corner frequency.
     f_high : float
@@ -49,25 +53,25 @@ def bandpass(data, f_low, f_high, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (P, N, M) or (N, M)
+        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
     """
     Wn = [f_low / (fsample / 2), f_high / (fsample / 2)]
     b, a = signal.butter(order, Wn, btype="bandpass")
 
     try:
-        P, N, M = np.shape(data)
+        W_windows, C_channels, S_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(P, N, M), dtype=float)
-        for p in range(0, P):
-            current_window = data[p, :, :]
-            new_data[p, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        new_data = np.ndarray(shape=(W_windows, C_channels, S_samples), dtype=float)
+        for W in range(0, W_windows):
+            current_window = data[W, :, :]
+            new_data[W, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
 
         return new_data
 
     except ValueError:
-        N, M = np.shape(data)
+        C_channels, S_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(N, M), dtype=float)
+        new_data = np.ndarray(shape=(C_channels, S_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -86,7 +90,7 @@ def lowpass(data, f_critical, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (P, N, M) or (N, M)
+        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -100,26 +104,26 @@ def lowpass(data, f_critical, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (P, N, M) or (N, M)
+        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="lowpass")
 
     try:
-        P, N, M = np.shape(data)
+        W_windows, C_channels, S_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(P, N, M), dtype=float)
-        for p in range(0, P):
-            for n in range(0, N):
-                current_window = data[p, n, :]
-                new_data[p, n, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        new_data = np.ndarray(shape=(W_windows, C_channels, S_samples), dtype=float)
+        for W in range(0, W_windows):
+            for C in range(0, C_channels):
+                current_window = data[W, C, :]
+                new_data[W, C, :] = signal.filtfilt(b, a, current_window, padlen=0)
 
         return new_data
 
     except ValueError:
-        N, M = np.shape(data)
+        C_channels, S_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(N, M), dtype=float)
+        new_data = np.ndarray(shape=(C_channels, S_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -138,7 +142,7 @@ def highpass(data, f_critical, order, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (P, N, M) or (N, M)
+        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
     f_critical : float
         Critical (cutoff) frequency.
     order : int
@@ -152,25 +156,25 @@ def highpass(data, f_critical, order, fsample):
         Windows of filtered EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (P, N, M) or (N, M)
+        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
     """
     Wn = f_critical / (fsample / 2)
     b, a = signal.butter(order, Wn, btype="highpass")
 
     try:
-        P, N, M = np.shape(data)
+        W_windows, C_channels, S_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(P, N, M), dtype=float)
-        for p in range(0, P):
-            current_window = data[p, :, :]
-            new_data[p, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        new_data = np.ndarray(shape=(W_windows, C_channels, S_samples), dtype=float)
+        for W in range(0, W_windows):
+            current_window = data[W, :, :]
+            new_data[W, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
 
         return new_data
 
     except ValueError:
-        N, M = np.shape(data)
+        C_channels, S_samples = np.shape(data)
 
-        new_data = np.ndarray(shape=(N, M), dtype=float)
+        new_data = np.ndarray(shape=(C_channels, S_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
 
         return new_data
@@ -187,7 +191,7 @@ def notch(data, f_notch, Q, fsample):
         Windows of EEG data.
         3D (or 2D) array containing data with `float` type.
 
-        shape = (P, N, M) or (N, M)
+        shape = (W_windows, C_channels, S_samples) or (C_channels, S_samples)
     f_notch : float
         Frequency of notch.
     Q : float
@@ -210,16 +214,16 @@ def notch(data, f_notch, Q, fsample):
     b, a = signal.iirnotch(f_notch, Q, fsample)
 
     try:
-        P, N, M = np.shape(data)
-        new_data = np.ndarray(shape=(P, N, M), dtype=float)
-        for p in range(0, P):
-            current_window = data[p, :, :]
-            new_data[p, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
+        W_windows, C_channels, S_samples = np.shape(data)
+        new_data = np.ndarray(shape=(W_windows, C_channels, S_samples), dtype=float)
+        for W in range(0, W_windows):
+            current_window = data[W, :, :]
+            new_data[W, :, :] = signal.filtfilt(b, a, current_window, padlen=0)
         return new_data
 
     except Exception:
-        N, M = np.shape(data)
-        new_data = np.ndarray(shape=(N, M), dtype=float)
+        C_channels, S_samples = np.shape(data)
+        new_data = np.ndarray(shape=(C_channels, S_samples), dtype=float)
         new_data = signal.filtfilt(b, a, data, padlen=0)
         return new_data
 
@@ -237,7 +241,7 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
         Windows of EEG data.
         3D array containing data with `float` type.
 
-        shape = (P, N, M)
+        shape = (W_windows, C_channels, S_samples)
     y : numpy.ndarray
         Labels corresponding to X.
     expansion_factor : int, *optional*
@@ -257,16 +261,16 @@ def lico(X, y, expansion_factor=3, sum_num=2, shuffle=False):
     """
     true_X = X[y == 1]
 
-    n, m, p = true_X.shape
+    W_windows, C_channels, S_samples = true_X.shape
     logger.info("Shape of ERPs only: %s", true_X.shape)
-    new_n = n * np.round(expansion_factor - 1)
-    new_X = np.zeros([new_n, m, p])
-    for i in range(n):
+    new_W = W_windows * np.round(expansion_factor - 1)
+    new_X = np.zeros([new_W, C_channels, S_samples])
+    for W in range(W_windows):
         for j in range(sum_num):
-            random_epoch = true_X[random.choice(range(n)), :, :]
-            new_X[i, :, :] += random_epoch / sum_num
+            random_epoch = true_X[random.choice(range(W_windows)), :, :]
+            new_X[W, :, :] += random_epoch / sum_num
 
     over_X = np.append(X, new_X, axis=0)
-    over_y = np.append(y, np.ones([new_n]))
+    over_y = np.append(y, np.ones([new_W]))
 
     return over_X, over_y

--- a/bci_essentials/utils/logger.py
+++ b/bci_essentials/utils/logger.py
@@ -95,7 +95,7 @@ the logging level and the message.
     >>> logger.logger.critical("This is a critical message")
 
 This is an example of including a variable in the output at the INFO level:
-    >>> logger.info("The number of channels is %s", num_channels)
+    >>> logger.info("The number of channels is %s", n_channels)
 
 
 Example 5: Changing the logging level after Logger instantiation

--- a/bci_essentials/visuals.py
+++ b/bci_essentials/visuals.py
@@ -3,8 +3,8 @@ Visualization toolbox for BCI Essentials
 
 The EEG data inputs for each function are either windows or
 decision blocks.
-- For windows, inputs are of the shape `num_windows x n_channels x n_samples`, where:
-    - num_windows = number of windows (for a single window `W_window = 1`)
+- For windows, inputs are of the shape `n_windows x n_channels x n_samples`, where:
+    - n_windows = number of windows (for a single window `W_window = 1`)
     - n_channels = number of channels
     - n_samples = number of samples
 - For decision blocks, inputs are of the shape `num_decisions x n_channels x n_samples`, where:
@@ -137,7 +137,7 @@ def plot_big_decision_block(
     `None`
 
     """
-    num_decisions, O, num_windows, n_channels, n_samples = big_decision_block.shape
+    num_decisions, O, n_windows, n_channels, n_samples = big_decision_block.shape
 
     num_decisions = 9
 
@@ -159,8 +159,8 @@ def plot_big_decision_block(
 
         # plot the ERP
         erp_label = erp_targets[decision]
-        # for window in num_windows plot the signal
-        for window in range(num_windows):
+        # for window in n_windows plot the signal
+        for window in range(n_windows):
             sum_range = big_decision_block[decision, erp_label, window, 0, 0:10].sum()
             if sum_range != 0:
                 for channel in range(n_channels):
@@ -172,7 +172,7 @@ def plot_big_decision_block(
                         color=color_string,
                     )
 
-                # plot the average of all num_windows in bold
+                # plot the average of all n_windows in bold
                 color_string = "C{}".format(int(channel))
             else:
                 break
@@ -194,8 +194,8 @@ def plot_big_decision_block(
 
         # plot any non ERP
         non_erp_label = 0
-        # for window in num_windows plot the signal
-        for window in range(num_windows):
+        # for window in n_windows plot the signal
+        for window in range(n_windows):
             sum_range = big_decision_block[
                 decision, non_erp_label, window, 0, 0:10
             ].sum()
@@ -209,7 +209,7 @@ def plot_big_decision_block(
                         color=color_string,
                     )
 
-                # plot the average of all num_windows in bold
+                # plot the average of all n_windows in bold
                 color_string = "C{}".format(int(channel))
             else:
                 break
@@ -230,9 +230,9 @@ def plot_big_decision_block(
         ax[1].set_title("Non-ERP on object{}".format(non_erp_label))
         ax[1].set_ylim(ylims)
         ax[1].legend()
-        # for window in num_windows plot the signal
+        # for window in n_windows plot the signal
 
-        # plot the average of all num_windows in bold
+        # plot the average of all n_windows in bold
 
         fig[decision].show()
 

--- a/bci_essentials/visuals.py
+++ b/bci_essentials/visuals.py
@@ -177,7 +177,9 @@ def plot_big_decision_block(
             else:
                 break
 
-        trial_mean_bdb = np.mean(big_decision_block[decision, erp_label, :, :, :], axis=0)
+        trial_mean_bdb = np.mean(
+            big_decision_block[decision, erp_label, :, :, :], axis=0
+        )
         for channel in range(n_channels):
             color_string = "C{}".format(int(channel))
             ax[0].plot(

--- a/bci_essentials/visuals.py
+++ b/bci_essentials/visuals.py
@@ -3,14 +3,14 @@ Visualization toolbox for BCI Essentials
 
 The EEG data inputs for each function are either windows or
 decision blocks.
-- For windows, inputs are of the shape `num_windows x num_channels x num_samples`, where:
+- For windows, inputs are of the shape `num_windows x n_channels x n_samples`, where:
     - num_windows = number of windows (for a single window `W_window = 1`)
-    - num_channels = number of channels
-    - num_samples = number of samples
-- For decision blocks, inputs are of the shape `num_decisions x num_channels x num_samples`, where:
+    - n_channels = number of channels
+    - n_samples = number of samples
+- For decision blocks, inputs are of the shape `num_decisions x n_channels x n_samples`, where:
     - num_decisions = number of possible decisions to select from
-    - num_channels = number of channels
-    - num_samples = number of samples
+    - n_channels = number of channels
+    - n_samples = number of samples
 
 """
 import matplotlib.pyplot as plt
@@ -34,7 +34,7 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
         A decision block of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_decisions`,`num_channels`,`num_samples`)
+        shape = (`num_decisions`,`n_channels`,`n_samples`)
     f_sample : float
         Sampling rate of the signal.
     label : int
@@ -51,15 +51,15 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
     `None`
 
     """
-    num_decisions, num_channels, num_samples = decision_block.shape
+    num_decisions, n_channels, n_samples = decision_block.shape
 
     # If no channel label then assign one based on its position
     if channel_labels == []:
-        channel_labels = [str(channel) for channel in range(num_channels)]
+        channel_labels = [str(channel) for channel in range(n_channels)]
 
     # Make time vector
-    t = np.ndarray((num_samples))
-    for sample in range(num_samples):
+    t = np.ndarray((n_samples))
+    for sample in range(n_samples):
         t[sample] = sample / f_sample
 
     # Initialize subplot
@@ -68,7 +68,7 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
         ax[decision] = plt.subplot(num_decisions + 1, 1, decision + 1)
 
     # Plot the ERP in the first subplot
-    # for channel in range(num_channels):
+    # for channel in range(n_channels):
     #     ax[0].plot(t, decision_block[label,channel,:], label=channel_labels[channel])
     #     ax[0].legend()
     #     ax[0].set_ylim(ylims)
@@ -78,7 +78,7 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
     for decision in range(num_decisions):
         if decision == label:
             decision_slice = decision_block[decision, :, :]
-            for channel in range(num_channels):
+            for channel in range(n_channels):
                 channel_data = decision_slice[channel, :]
                 ax[ind].plot(t, channel_data, label=channel_labels[channel])
 
@@ -90,7 +90,7 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
 
         else:
             decision_slice = decision_block[ind, :, :]
-            for channel in range(num_channels):
+            for channel in range(n_channels):
                 channel_data = decision_slice[channel, :]
                 ax[ind].plot(t, channel_data, label=channel_labels[channel])
 
@@ -117,7 +117,7 @@ def plot_big_decision_block(
         A decision block of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_channels`,`num_samples`,`P_selections`)
+        shape = (`n_channels`,`n_samples`,`P_selections`)
     f_sample : float
         Sampling rate of the signal.
     label : int
@@ -137,17 +137,17 @@ def plot_big_decision_block(
     `None`
 
     """
-    num_decisions, O, num_windows, num_channels, num_samples = big_decision_block.shape
+    num_decisions, O, num_windows, n_channels, n_samples = big_decision_block.shape
 
     num_decisions = 9
 
     # Give default channel names if none are given
     if channel_labels == []:
-        channel_labels = [str(channel) for channel in range(num_channels)]
+        channel_labels = [str(channel) for channel in range(n_channels)]
 
     # Make time vector
-    t = np.ndarray((num_samples))
-    for sample in range(num_samples):
+    t = np.ndarray((n_samples))
+    for sample in range(n_samples):
         t[sample] = sample / f_sample
 
     fig = [None] * num_decisions
@@ -163,7 +163,7 @@ def plot_big_decision_block(
         for window in range(num_windows):
             sum_range = big_decision_block[decision, erp_label, window, 0, 0:10].sum()
             if sum_range != 0:
-                for channel in range(num_channels):
+                for channel in range(n_channels):
                     color_string = "C{}".format(int(channel))
                     ax[0].plot(
                         t,
@@ -178,7 +178,7 @@ def plot_big_decision_block(
                 break
 
         win_mean_bdb = np.mean(big_decision_block[decision, erp_label, :, :, :], axis=0)
-        for channel in range(num_channels):
+        for channel in range(n_channels):
             color_string = "C{}".format(int(channel))
             ax[0].plot(
                 t,
@@ -200,7 +200,7 @@ def plot_big_decision_block(
                 decision, non_erp_label, window, 0, 0:10
             ].sum()
             if sum_range != 0:
-                for channel in range(num_channels):
+                for channel in range(n_channels):
                     color_string = "C{}".format(int(channel))
                     ax[1].plot(
                         t,
@@ -217,7 +217,7 @@ def plot_big_decision_block(
         win_mean_bdb = np.mean(
             big_decision_block[decision, non_erp_label, :, :, :], axis=0
         )
-        for channel in range(num_channels):
+        for channel in range(n_channels):
             color_string = "C{}".format(int(channel))
             ax[1].plot(
                 t,
@@ -247,7 +247,7 @@ def plot_window(eeg_data_window, f_sample, channel_labels=[]):
         A window of EEG data.
         2D array containing data with `float` type.
 
-        shape = (`num_channels`,`num_samples`)
+        shape = (`n_channels`,`n_samples`)
     f_sample : float
         Sampling rate of the signal.
     channel_labels : list, *optional*
@@ -259,20 +259,20 @@ def plot_window(eeg_data_window, f_sample, channel_labels=[]):
     `None`
 
     """
-    num_channels, num_samples = eeg_data_window.shape
+    n_channels, n_samples = eeg_data_window.shape
 
     # If no channel label then assign one based on its position
     if channel_labels == []:
-        channel_labels = [str(channel) for channel in range(num_channels)]
+        channel_labels = [str(channel) for channel in range(n_channels)]
 
     # Make time vector
-    t = np.ndarray((num_samples))
-    for sample in range(num_samples):
+    t = np.ndarray((n_samples))
+    for sample in range(n_samples):
         t[sample] = sample / f_sample
 
-    fig, axs = plt.subplots(num_channels)
+    fig, axs = plt.subplots(n_channels)
 
-    for channel in range(num_channels):
+    for channel in range(n_channels):
         channel_data = eeg_data_window[channel, :]
         axs[channel].plot(t, channel_data)
         axs[channel].ylabel = channel_labels[channel]

--- a/bci_essentials/visuals.py
+++ b/bci_essentials/visuals.py
@@ -7,8 +7,8 @@ decision blocks.
     - n_trials = number of trials (for a single trial `n_trials = 1`)
     - n_channels = number of channels
     - n_samples = number of samples
-- For decision blocks, inputs are of the shape `num_decisions x n_channels x n_samples`, where:
-    - num_decisions = number of possible decisions to select from
+- For decision blocks, inputs are of the shape `n_decisions x n_channels x n_samples`, where:
+    - n_decisions = number of possible decisions to select from
     - n_channels = number of channels
     - n_samples = number of samples
 
@@ -34,7 +34,7 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
         A decision block of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`num_decisions`,`n_channels`,`n_samples`)
+        shape = (`n_decisions`,`n_channels`,`n_samples`)
     f_sample : float
         Sampling rate of the signal.
     label : int
@@ -51,7 +51,7 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
     `None`
 
     """
-    num_decisions, n_channels, n_samples = decision_block.shape
+    n_decisions, n_channels, n_samples = decision_block.shape
 
     # If no channel label then assign one based on its position
     if channel_labels == []:
@@ -63,9 +63,9 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
         t[sample] = sample / f_sample
 
     # Initialize subplot
-    ax = [0] * num_decisions
-    for decision in range(num_decisions):
-        ax[decision] = plt.subplot(num_decisions + 1, 1, decision + 1)
+    ax = [0] * n_decisions
+    for decision in range(n_decisions):
+        ax[decision] = plt.subplot(n_decisions + 1, 1, decision + 1)
 
     # Plot the ERP in the first subplot
     # for channel in range(n_channels):
@@ -75,7 +75,7 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
 
     ind = 0
     # Plot non ERP in the subsequent subplots
-    for decision in range(num_decisions):
+    for decision in range(n_decisions):
         if decision == label:
             decision_slice = decision_block[decision, :, :]
             for channel in range(n_channels):
@@ -137,9 +137,9 @@ def plot_big_decision_block(
     `None`
 
     """
-    num_decisions, O, n_trials, n_channels, n_samples = big_decision_block.shape
+    n_decisions, O, n_trials, n_channels, n_samples = big_decision_block.shape
 
-    num_decisions = 9
+    n_decisions = 9
 
     # Give default channel names if none are given
     if channel_labels == []:
@@ -150,9 +150,9 @@ def plot_big_decision_block(
     for sample in range(n_samples):
         t[sample] = sample / f_sample
 
-    fig = [None] * num_decisions
-    # for decision in num_decisions create a figure
-    for decision in range(num_decisions):
+    fig = [None] * n_decisions
+    # for decision in n_decisions create a figure
+    for decision in range(n_decisions):
         fig[decision], ax = plt.subplots(nrows=2, ncols=1)
 
         # for ERP in O and one non ERP in O, each in own subplot

--- a/bci_essentials/visuals.py
+++ b/bci_essentials/visuals.py
@@ -3,14 +3,14 @@ Visualization toolbox for BCI Essentials
 
 The EEG data inputs for each function are either windows or
 decision blocks.
-- For windows, inputs are of the shape `N x M x P`, where:
-    - N = number of channels
-    - M = number of samples
-    - P = number of windows (for a single window `P = 1`)
-- For decision blocks, inputs are of the shape `N x M x P`, where:
-    - N = number of channels
-    - M = number of samples
-    - P = number of possible selections
+- For windows, inputs are of the shape `num_windows x num_channels x num_samples`, where:
+    - num_windows = number of windows (for a single window `W_window = 1`)
+    - num_channels = number of channels
+    - num_samples = number of samples
+- For decision blocks, inputs are of the shape `num_decisions x num_channels x num_samples`, where:
+    - num_decisions = number of possible decisions to select from
+    - num_channels = number of channels
+    - num_samples = number of samples
 
 """
 import matplotlib.pyplot as plt
@@ -34,7 +34,7 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
         A decision block of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`N_channels`,`M_samples`,`P_selections`)
+        shape = (`num_decisions`,`num_channels`,`num_samples`)
     f_sample : float
         Sampling rate of the signal.
     label : int
@@ -51,36 +51,36 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
     `None`
 
     """
-    P, N, M = decision_block.shape
+    num_decisions, num_channels, num_samples = decision_block.shape
 
     # If no channel label then assign one based on its position
     if channel_labels == []:
-        channel_labels = [str(n) for n in range(N)]
+        channel_labels = [str(channel) for channel in range(num_channels)]
 
     # Make time vector
-    t = np.ndarray((M))
-    for m in range(M):
-        t[m] = m / f_sample
+    t = np.ndarray((num_samples))
+    for sample in range(num_samples):
+        t[sample] = sample / f_sample
 
     # Initialize subplot
-    ax = [0] * P
-    for p in range(P):
-        ax[p] = plt.subplot(P + 1, 1, p + 1)
+    ax = [0] * num_decisions
+    for decision in range(num_decisions):
+        ax[decision] = plt.subplot(num_decisions + 1, 1, decision + 1)
 
     # Plot the ERP in the first subplot
-    # for n in range(N):
-    #     ax[0].plot(t, decision_block[label,n,:], label=channel_labels[n])
+    # for channel in range(num_channels):
+    #     ax[0].plot(t, decision_block[label,channel,:], label=channel_labels[channel])
     #     ax[0].legend()
     #     ax[0].set_ylim(ylims)
 
     ind = 0
     # Plot non ERP in the subsequent subplots
-    for p in range(P):
-        if p == label:
-            decision_slice = decision_block[p, :, :]
-            for n in range(N):
-                channel_data = decision_slice[n, :]
-                ax[ind].plot(t, channel_data, label=channel_labels[n])
+    for decision in range(num_decisions):
+        if decision == label:
+            decision_slice = decision_block[decision, :, :]
+            for channel in range(num_channels):
+                channel_data = decision_slice[channel, :]
+                ax[ind].plot(t, channel_data, label=channel_labels[channel])
 
             ax[ind].legend()
             ax[ind].set_ylim(ylims)
@@ -90,9 +90,9 @@ def decision_vis(decision_block, f_sample, label, channel_labels=[], ylims=(-100
 
         else:
             decision_slice = decision_block[ind, :, :]
-            for n in range(N):
-                channel_data = decision_slice[n, :]
-                ax[ind].plot(t, channel_data, label=channel_labels[n])
+            for channel in range(num_channels):
+                channel_data = decision_slice[channel, :]
+                ax[ind].plot(t, channel_data, label=channel_labels[channel])
 
             ax[ind].set_ylim(ylims)
             ax[ind].legend()
@@ -117,7 +117,7 @@ def plot_big_decision_block(
         A decision block of EEG data.
         3D array containing data with `float` type.
 
-        shape = (`N_channels`,`M_samples`,`P_selections`)
+        shape = (`num_channels`,`num_samples`,`P_selections`)
     f_sample : float
         Sampling rate of the signal.
     label : int
@@ -137,53 +137,53 @@ def plot_big_decision_block(
     `None`
 
     """
-    D, O, W, N, M = big_decision_block.shape
+    num_decisions, O, num_windows, num_channels, num_samples = big_decision_block.shape
 
-    D = 9
+    num_decisions = 9
 
     # Give default channel names if none are given
     if channel_labels == []:
-        channel_labels = [str(n) for n in range(N)]
+        channel_labels = [str(channel) for channel in range(num_channels)]
 
     # Make time vector
-    t = np.ndarray((M))
-    for m in range(M):
-        t[m] = m / f_sample
+    t = np.ndarray((num_samples))
+    for sample in range(num_samples):
+        t[sample] = sample / f_sample
 
-    fig = [None] * D
-    # for d in D create a figure
-    for d in range(D):
-        fig[d], ax = plt.subplots(nrows=2, ncols=1)
+    fig = [None] * num_decisions
+    # for decision in num_decisions create a figure
+    for decision in range(num_decisions):
+        fig[decision], ax = plt.subplots(nrows=2, ncols=1)
 
         # for ERP in O and one non ERP in O, each in own subplot
 
         # plot the ERP
-        erp_label = erp_targets[d]
-        # for w in W plot the signal
-        for w in range(W):
-            sum_range = big_decision_block[d, erp_label, w, 0, 0:10].sum()
+        erp_label = erp_targets[decision]
+        # for window in num_windows plot the signal
+        for window in range(num_windows):
+            sum_range = big_decision_block[decision, erp_label, window, 0, 0:10].sum()
             if sum_range != 0:
-                for n in range(N):
-                    color_string = "C{}".format(int(n))
+                for channel in range(num_channels):
+                    color_string = "C{}".format(int(channel))
                     ax[0].plot(
                         t,
-                        big_decision_block[d, erp_label, w, n, :],
-                        label=channel_labels[n],
+                        big_decision_block[decision, erp_label, window, channel, :],
+                        label=channel_labels[channel],
                         color=color_string,
                     )
 
-                # plot the average of all W in bold
-                color_string = "C{}".format(int(n))
+                # plot the average of all num_windows in bold
+                color_string = "C{}".format(int(channel))
             else:
                 break
 
-        win_mean_bdb = np.mean(big_decision_block[d, erp_label, :, :, :], axis=0)
-        for n in range(N):
-            color_string = "C{}".format(int(n))
+        win_mean_bdb = np.mean(big_decision_block[decision, erp_label, :, :, :], axis=0)
+        for channel in range(num_channels):
+            color_string = "C{}".format(int(channel))
             ax[0].plot(
                 t,
-                win_mean_bdb[n, :],
-                label=channel_labels[n],
+                win_mean_bdb[channel, :],
+                label=channel_labels[channel],
                 color=color_string,
                 linewidth=1.0,
             )
@@ -194,31 +194,35 @@ def plot_big_decision_block(
 
         # plot any non ERP
         non_erp_label = 0
-        # for w in W plot the signal
-        for w in range(W):
-            sum_range = big_decision_block[d, non_erp_label, w, 0, 0:10].sum()
+        # for window in num_windows plot the signal
+        for window in range(num_windows):
+            sum_range = big_decision_block[
+                decision, non_erp_label, window, 0, 0:10
+            ].sum()
             if sum_range != 0:
-                for n in range(N):
-                    color_string = "C{}".format(int(n))
+                for channel in range(num_channels):
+                    color_string = "C{}".format(int(channel))
                     ax[1].plot(
                         t,
-                        big_decision_block[d, non_erp_label, w, n, :],
-                        label=channel_labels[n],
+                        big_decision_block[decision, non_erp_label, window, channel, :],
+                        label=channel_labels[channel],
                         color=color_string,
                     )
 
-                # plot the average of all W in bold
-                color_string = "C{}".format(int(n))
+                # plot the average of all num_windows in bold
+                color_string = "C{}".format(int(channel))
             else:
                 break
 
-        win_mean_bdb = np.mean(big_decision_block[d, non_erp_label, :, :, :], axis=0)
-        for n in range(N):
-            color_string = "C{}".format(int(n))
+        win_mean_bdb = np.mean(
+            big_decision_block[decision, non_erp_label, :, :, :], axis=0
+        )
+        for channel in range(num_channels):
+            color_string = "C{}".format(int(channel))
             ax[1].plot(
                 t,
-                win_mean_bdb[n, :],
-                label=channel_labels[n],
+                win_mean_bdb[channel, :],
+                label=channel_labels[channel],
                 color=color_string,
                 linewidth=1.0,
             )
@@ -226,24 +230,24 @@ def plot_big_decision_block(
         ax[1].set_title("Non-ERP on object{}".format(non_erp_label))
         ax[1].set_ylim(ylims)
         ax[1].legend()
-        # for w in W plot the signal
+        # for window in num_windows plot the signal
 
-        # plot the average of all W in bold
+        # plot the average of all num_windows in bold
 
-        fig[d].show()
+        fig[decision].show()
 
 
 # Plot window
-def plot_window(window, f_sample, channel_labels=[]):
+def plot_window(eeg_data_window, f_sample, channel_labels=[]):
     """Plots a window of EEG data.
 
     Parameters
     ----------
-    window : numpy.ndarray
+    eeg_data_windowa : numpy.ndarray
         A window of EEG data.
         2D array containing data with `float` type.
 
-        shape = (`N_channels`,`M_samples`)
+        shape = (`num_channels`,`num_samples`)
     f_sample : float
         Sampling rate of the signal.
     channel_labels : list, *optional*
@@ -255,22 +259,22 @@ def plot_window(window, f_sample, channel_labels=[]):
     `None`
 
     """
-    N, M = window.shape
+    num_channels, num_samples = eeg_data_window.shape
 
     # If no channel label then assign one based on its position
     if channel_labels == []:
-        channel_labels = [str(n) for n in range(N)]
+        channel_labels = [str(channel) for channel in range(num_channels)]
 
     # Make time vector
-    t = np.ndarray((M))
-    for m in range(M):
-        t[m] = m / f_sample
+    t = np.ndarray((num_samples))
+    for sample in range(num_samples):
+        t[sample] = sample / f_sample
 
-    fig, axs = plt.subplots(N)
+    fig, axs = plt.subplots(num_channels)
 
-    for n in range(N):
-        channel_data = window[n, :]
-        axs[n].plot(t, channel_data)
-        axs[n].ylabel = channel_labels[n]
+    for channel in range(num_channels):
+        channel_data = eeg_data_window[channel, :]
+        axs[channel].plot(t, channel_data)
+        axs[channel].ylabel = channel_labels[channel]
 
     fig.show()

--- a/bci_essentials/visuals.py
+++ b/bci_essentials/visuals.py
@@ -1,10 +1,10 @@
 """
 Visualization toolbox for BCI Essentials
 
-The EEG data inputs for each function are either windows or
+The EEG data inputs for each function are either trials or
 decision blocks.
-- For windows, inputs are of the shape `n_windows x n_channels x n_samples`, where:
-    - n_windows = number of windows (for a single window `W_window = 1`)
+- For trials, inputs are of the shape `n_trials x n_channels x n_samples`, where:
+    - n_trials = number of trials (for a single trial `n_trials = 1`)
     - n_channels = number of channels
     - n_samples = number of samples
 - For decision blocks, inputs are of the shape `num_decisions x n_channels x n_samples`, where:
@@ -137,7 +137,7 @@ def plot_big_decision_block(
     `None`
 
     """
-    num_decisions, O, n_windows, n_channels, n_samples = big_decision_block.shape
+    num_decisions, O, n_trials, n_channels, n_samples = big_decision_block.shape
 
     num_decisions = 9
 
@@ -159,30 +159,30 @@ def plot_big_decision_block(
 
         # plot the ERP
         erp_label = erp_targets[decision]
-        # for window in n_windows plot the signal
-        for window in range(n_windows):
-            sum_range = big_decision_block[decision, erp_label, window, 0, 0:10].sum()
+        # for trial in n_trials plot the signal
+        for trial in range(n_trials):
+            sum_range = big_decision_block[decision, erp_label, trial, 0, 0:10].sum()
             if sum_range != 0:
                 for channel in range(n_channels):
                     color_string = "C{}".format(int(channel))
                     ax[0].plot(
                         t,
-                        big_decision_block[decision, erp_label, window, channel, :],
+                        big_decision_block[decision, erp_label, trial, channel, :],
                         label=channel_labels[channel],
                         color=color_string,
                     )
 
-                # plot the average of all n_windows in bold
+                # plot the average of all n_trials in bold
                 color_string = "C{}".format(int(channel))
             else:
                 break
 
-        win_mean_bdb = np.mean(big_decision_block[decision, erp_label, :, :, :], axis=0)
+        trial_mean_bdb = np.mean(big_decision_block[decision, erp_label, :, :, :], axis=0)
         for channel in range(n_channels):
             color_string = "C{}".format(int(channel))
             ax[0].plot(
                 t,
-                win_mean_bdb[channel, :],
+                trial_mean_bdb[channel, :],
                 label=channel_labels[channel],
                 color=color_string,
                 linewidth=1.0,
@@ -194,34 +194,34 @@ def plot_big_decision_block(
 
         # plot any non ERP
         non_erp_label = 0
-        # for window in n_windows plot the signal
-        for window in range(n_windows):
+        # for trial in n_trials plot the signal
+        for trial in range(n_trials):
             sum_range = big_decision_block[
-                decision, non_erp_label, window, 0, 0:10
+                decision, non_erp_label, trial, 0, 0:10
             ].sum()
             if sum_range != 0:
                 for channel in range(n_channels):
                     color_string = "C{}".format(int(channel))
                     ax[1].plot(
                         t,
-                        big_decision_block[decision, non_erp_label, window, channel, :],
+                        big_decision_block[decision, non_erp_label, trial, channel, :],
                         label=channel_labels[channel],
                         color=color_string,
                     )
 
-                # plot the average of all n_windows in bold
+                # plot the average of all n_trials in bold
                 color_string = "C{}".format(int(channel))
             else:
                 break
 
-        win_mean_bdb = np.mean(
+        trial_mean_bdb = np.mean(
             big_decision_block[decision, non_erp_label, :, :, :], axis=0
         )
         for channel in range(n_channels):
             color_string = "C{}".format(int(channel))
             ax[1].plot(
                 t,
-                win_mean_bdb[channel, :],
+                trial_mean_bdb[channel, :],
                 label=channel_labels[channel],
                 color=color_string,
                 linewidth=1.0,
@@ -230,21 +230,21 @@ def plot_big_decision_block(
         ax[1].set_title("Non-ERP on object{}".format(non_erp_label))
         ax[1].set_ylim(ylims)
         ax[1].legend()
-        # for window in n_windows plot the signal
+        # for trial in n_trials plot the signal
 
-        # plot the average of all n_windows in bold
+        # plot the average of all n_trials in bold
 
         fig[decision].show()
 
 
-# Plot window
-def plot_window(eeg_data_window, f_sample, channel_labels=[]):
-    """Plots a window of EEG data.
+# Plot trial
+def plot_trial(eeg_data_trial, f_sample, channel_labels=[]):
+    """Plots a trial of EEG data.
 
     Parameters
     ----------
-    eeg_data_windowa : numpy.ndarray
-        A window of EEG data.
+    eeg_data_triala : numpy.ndarray
+        A trial of EEG data.
         2D array containing data with `float` type.
 
         shape = (`n_channels`,`n_samples`)
@@ -259,7 +259,7 @@ def plot_window(eeg_data_window, f_sample, channel_labels=[]):
     `None`
 
     """
-    n_channels, n_samples = eeg_data_window.shape
+    n_channels, n_samples = eeg_data_trial.shape
 
     # If no channel label then assign one based on its position
     if channel_labels == []:
@@ -273,7 +273,7 @@ def plot_window(eeg_data_window, f_sample, channel_labels=[]):
     fig, axs = plt.subplots(n_channels)
 
     for channel in range(n_channels):
-        channel_data = eeg_data_window[channel, :]
+        channel_data = eeg_data_trial[channel, :]
         axs[channel].plot(t, channel_data)
         axs[channel].ylabel = channel_labels[channel]
 

--- a/docs/bci_essentials_diagram.drawio
+++ b/docs/bci_essentials_diagram.drawio
@@ -29,7 +29,7 @@
             <mxRectangle x="230" y="140" width="160" height="26" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="zkfFHV4jXpPFQw0GAbJ--1" value="Settings including max channels, &#xa;windows, timeout, etc." style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="zkfFHV4jXpPFQw0GAbJ--0" vertex="1">
+        <mxCell id="zkfFHV4jXpPFQw0GAbJ--1" value="Settings including max channels, &#xa;trials, timeout, etc." style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="zkfFHV4jXpPFQw0GAbJ--0" vertex="1">
           <mxGeometry y="26" width="210" height="44" as="geometry" />
         </mxCell>
         <mxCell id="6OChiqeG2Fh9RAyOYw9k-16" value="EEG info including channel types, &#xa;labels, units, headset, sampling rate.&#xa;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" vertex="1" parent="zkfFHV4jXpPFQw0GAbJ--0">
@@ -38,7 +38,7 @@
         <mxCell id="VehVQyyuWz1h-YvdvVy--43" value="Marker info including markers and &#xa;their timestamps both ingoing and &#xa;outgoing." style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" vertex="1" parent="zkfFHV4jXpPFQw0GAbJ--0">
           <mxGeometry y="114" width="210" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="VehVQyyuWz1h-YvdvVy--44" value="Structured EEG including # windows,&#xa;# samples, raw structured data, and&#xa;processed structured data.&#xa;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" vertex="1" parent="zkfFHV4jXpPFQw0GAbJ--0">
+        <mxCell id="VehVQyyuWz1h-YvdvVy--44" value="Structured EEG including # trials,&#xa;# samples, raw structured data, and&#xa;processed structured data.&#xa;" style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" vertex="1" parent="zkfFHV4jXpPFQw0GAbJ--0">
           <mxGeometry y="174" width="210" height="56" as="geometry" />
         </mxCell>
         <mxCell id="VehVQyyuWz1h-YvdvVy--45" value="Classifier object." style="text;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" vertex="1" parent="zkfFHV4jXpPFQw0GAbJ--0">

--- a/examples/mne/mne_raw_from_xdf.py
+++ b/examples/mne/mne_raw_from_xdf.py
@@ -21,7 +21,7 @@ eeg_data, eeg_timestamps = eeg_source.get_samples()
 
 # Parse EEG to MNE
 info = mne.create_info(
-    eeg_source.channel_labels, eeg_source.fsample, ["eeg"] * eeg_source.nchannels
+    eeg_source.channel_labels, eeg_source.fsample, ["eeg"] * eeg_source.num_channels
 )
 raw = mne.io.RawArray(np.transpose(eeg_data[:, :16]), info)
 raw.filter(l_freq=0.1, h_freq=15)

--- a/examples/mne/mne_raw_from_xdf.py
+++ b/examples/mne/mne_raw_from_xdf.py
@@ -21,7 +21,7 @@ eeg_data, eeg_timestamps = eeg_source.get_samples()
 
 # Parse EEG to MNE
 info = mne.create_info(
-    eeg_source.channel_labels, eeg_source.fsample, ["eeg"] * eeg_source.num_channels
+    eeg_source.channel_labels, eeg_source.fsample, ["eeg"] * eeg_source.n_channels
 )
 raw = mne.io.RawArray(np.transpose(eeg_data[:, :16]), info)
 raw.filter(l_freq=0.1, h_freq=15)

--- a/examples/mne/p300_mne_plotting.py
+++ b/examples/mne/p300_mne_plotting.py
@@ -43,8 +43,8 @@ test_erp.setup(
     pp_high=10,
     pp_order=5,
     plot_erp=False,
-    window_start=0.0,
-    window_end=0.8,
+    trial_start=0.0,
+    trial_end=0.8,
 )
 test_erp.run()
 

--- a/examples/mne/saving.py
+++ b/examples/mne/saving.py
@@ -73,7 +73,7 @@ def mne_export_as_epochs(eeg_data_object):
     # create the MNE epochs, pass in the raw
 
     # make sure that units match
-    epoch_data = eeg_data_object.raw_eeg_windows.copy()
+    epoch_data = eeg_data_object.raw_eeg_trials.copy()
     for i, u in enumerate(eeg_data_object.ch_units):
         if u == "microvolts":
             # convert to volts
@@ -124,7 +124,7 @@ def mne_export_resting_state_as_raw(eeg_data_object):
         # create the MNE epochs, pass in the raw
 
         # make sure that units match
-        raw_data = eeg_data_object.rest_windows[0, :, :]
+        raw_data = eeg_data_object.rest_trials[0, :, :]
         raw_array = mne.io.RawArray(data=raw_data, info=info)
 
         # change the last column of epochs array events to be the class labels
@@ -167,8 +167,8 @@ def mne_export_erp_as_epochs(erp_data_object):
     # create the MNE epochs, pass in the raw
 
     # make sure that units match
-    # This only works because ErpData.erp_windows_processed is not private, like it probable should be
-    epoch_data = erp_data_object.erp_windows_processed[
+    # This only works because ErpData.erp_trials_processed is not private, like it probable should be
+    epoch_data = erp_data_object.erp_trials_processed[
         : len(erp_data_object.target_index), :, :
     ].copy()
     for i, u in enumerate(erp_data_object.ch_units):
@@ -219,13 +219,13 @@ def mne_export_erp_as_evoked(erp_data_object):
     # # create the MNE epochs, pass in the raw
 
     # # make sure that units match
-    # evoked_data = erp_data_object.raw_eeg_windows.copy()
+    # evoked_data = erp_data_object.raw_eeg_trials.copy()
     # for i, u in enumerate(erp_data_object.ch_units):
     #     if u == "microvolts":
     #         # convert to volts
     #         evoked_data[:,i,:] = evoked_data[:,i,:] / 1000000
 
-    # evoked_array = mne.EpochsArray(data=evoked_data, info=info, tmin=erp_data_object.window_start)
+    # evoked_array = mne.EpochsArray(data=evoked_data, info=info, tmin=erp_data_object.trial_start)
 
     # # change the last column of epochs array events to be the class labels
     # evoked_array.events[:, -1] = erp_data_object.labels

--- a/examples/p300_ch_select_test.py
+++ b/examples/p300_ch_select_test.py
@@ -57,8 +57,8 @@ test_erp.setup(
     pp_high=10,
     pp_order=5,
     plot_erp=False,
-    window_start=0.0,
-    window_end=0.8,
+    trial_start=0.0,
+    trial_end=0.8,
 )
 test_erp.run()
 

--- a/examples/p300_offline_test.py
+++ b/examples/p300_offline_test.py
@@ -39,7 +39,7 @@ test_erp.setup(
     pp_high=10,
     pp_order=5,
     plot_erp=False,
-    window_start=0.0,
-    window_end=0.8,
+    trial_start=0.0,
+    trial_end=0.8,
 )
 test_erp.run()

--- a/examples/p300_unity_backend.py
+++ b/examples/p300_unity_backend.py
@@ -31,7 +31,7 @@ test_erp.setup(
     pp_high=10,
     pp_order=5,
     plot_erp=False,
-    window_start=0.0,
-    window_end=0.8,
+    trial_start=0.0,
+    trial_end=0.8,
 )
 test_erp.run()

--- a/examples/rs_offline_test.py
+++ b/examples/rs_offline_test.py
@@ -65,13 +65,13 @@ except Exception:
             training=True,
             online=False,
             max_num_options=9,
-            max_windows_per_option=16,
+            max_trials_per_option=16,
             pp_low=0.1,
             pp_high=15,
             pp_order=5,
             plot_erp=False,
-            window_start=0.0,
-            window_end=0.6,
+            trial_start=0.0,
+            trial_end=0.6,
         )
         test_rs.run()
 
@@ -79,17 +79,17 @@ except Exception:
         logger.error("Couldn't find resting state data")
 
 try:
-    eyes_open_windows = test_rs.eyes_open_windows
+    eyes_open_trials = test_rs.eyes_open_trials
 except Exception:
     logger.error("Couldn't find eyes open data")
 
 try:
-    eyes_closed_windows = test_rs.eyes_closed_windows
+    eyes_closed_trials = test_rs.eyes_closed_trials
 except Exception:
     logger.error("Couldn't find eyes closed data")
 
 try:
-    rest_windows = test_rs.rest_windows
+    rest_trials = test_rs.rest_trials
 except Exception:
     logger.error("Couldn't find rest data")
 
@@ -97,11 +97,11 @@ fsample = test_rs.fsample
 channel_labels = test_rs.channel_labels
 
 # Get alpha peak from eyes closed?
-get_alpha_peak(eyes_closed_windows, alpha_min=8, alpha_max=12, plot_psd=False)
+get_alpha_peak(eyes_closed_trials, alpha_min=8, alpha_max=12, plot_psd=False)
 
 # Get bandpower features from eyes open
 abs_bandpower, rel_bandpower, rel_bandpower_mat = get_bandpower_features(
-    eyes_open_windows, fs=fsample, transition_freqs=[1, 4, 8, 12, 30]
+    eyes_open_trials, fs=fsample, transition_freqs=[1, 4, 8, 12, 30]
 )
 
 logger.info(

--- a/tests/test_classifier_save.py
+++ b/tests/test_classifier_save.py
@@ -113,10 +113,10 @@ class TestClassifierSave(unittest.TestCase):
             pp_high=10,
             pp_order=5,
             plot_erp=False,
-            window_start=0.0,
-            window_end=0.8,
+            trial_start=0.0,
+            trial_end=0.8,
             max_num_options=9,
-            max_windows_per_option=16,
+            max_trials_per_option=16,
             max_decisions=20,
         )
         data1.run()
@@ -149,10 +149,10 @@ class TestClassifierSave(unittest.TestCase):
             pp_high=10,
             pp_order=5,
             plot_erp=False,
-            window_start=0.0,
-            window_end=0.8,
+            trial_start=0.0,
+            trial_end=0.8,
             max_num_options=9,
-            max_windows_per_option=16,
+            max_trials_per_option=16,
             max_decisions=20,
         )
         data2.run()

--- a/tests/test_eeg_data.py
+++ b/tests/test_eeg_data.py
@@ -22,19 +22,19 @@ class TestEegData(unittest.TestCase):
     def test_dsi7_mods(self):
         self.eeg.name = "DSI7"
         self.eeg.channel_labels = ["foo"] * 8
-        self.eeg.num_channels = 8
+        self.eeg.n_channels = 8
         data = EegData(self.classifier, self.eeg, self.markers)
 
-        self.assertEqual(data.num_channels, 7)
+        self.assertEqual(data.n_channels, 7)
         self.assertEqual(len(data.channel_labels), 7)
 
     def test_dsi24_mods(self):
         self.eeg.name = "DSI24"
         self.eeg.channel_labels = ["foo"] * 24
-        self.eeg.num_channels = 24
+        self.eeg.n_channels = 24
         data = EegData(self.classifier, self.eeg, self.markers)
 
-        self.assertEqual(data.num_channels, 23)
+        self.assertEqual(data.n_channels, 23)
         self.assertEqual(len(data.channel_labels), 23)
 
     # offline
@@ -111,7 +111,7 @@ class _MockMarkerSource(MarkerSource):
 class _MockEegSource(EegSource):
     name = "MockEeg"
     fsample = 0.0
-    num_channels = 0
+    n_channels = 0
     channel_types = []
     channel_units = []
     channel_labels = []

--- a/tests/test_eeg_data.py
+++ b/tests/test_eeg_data.py
@@ -22,19 +22,19 @@ class TestEegData(unittest.TestCase):
     def test_dsi7_mods(self):
         self.eeg.name = "DSI7"
         self.eeg.channel_labels = ["foo"] * 8
-        self.eeg.nchannels = 8
+        self.eeg.num_channels = 8
         data = EegData(self.classifier, self.eeg, self.markers)
 
-        self.assertEqual(data.nchannels, 7)
+        self.assertEqual(data.num_channels, 7)
         self.assertEqual(len(data.channel_labels), 7)
 
     def test_dsi24_mods(self):
         self.eeg.name = "DSI24"
         self.eeg.channel_labels = ["foo"] * 24
-        self.eeg.nchannels = 24
+        self.eeg.num_channels = 24
         data = EegData(self.classifier, self.eeg, self.markers)
 
-        self.assertEqual(data.nchannels, 23)
+        self.assertEqual(data.num_channels, 23)
         self.assertEqual(len(data.channel_labels), 23)
 
     # offline
@@ -111,7 +111,7 @@ class _MockMarkerSource(MarkerSource):
 class _MockEegSource(EegSource):
     name = "MockEeg"
     fsample = 0.0
-    nchannels = 0
+    num_channels = 0
     channel_types = []
     channel_units = []
     channel_labels = []

--- a/tests/test_lsl_sources.py
+++ b/tests/test_lsl_sources.py
@@ -47,7 +47,7 @@ class TestLslEegSource(unittest.TestCase):
         self.assertEqual(self.source.fsample, 128.0)
 
     def test_eeg_nchannel(self):
-        self.assertEqual(self.source.num_channels, 8)
+        self.assertEqual(self.source.n_channels, 8)
 
     def test_eeg_channel(self):
         self.assertEqual(len(self.source.channel_types), 8)

--- a/tests/test_lsl_sources.py
+++ b/tests/test_lsl_sources.py
@@ -47,7 +47,7 @@ class TestLslEegSource(unittest.TestCase):
         self.assertEqual(self.source.fsample, 128.0)
 
     def test_eeg_nchannel(self):
-        self.assertEqual(self.source.nchannels, 8)
+        self.assertEqual(self.source.num_channels, 8)
 
     def test_eeg_channel(self):
         self.assertEqual(len(self.source.channel_types), 8)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -82,10 +82,10 @@ class TestSmoke(unittest.TestCase):
             pp_high=10,
             pp_order=5,
             plot_erp=False,
-            window_start=0.0,
-            window_end=0.8,
+            trial_start=0.0,
+            trial_end=0.8,
             max_num_options=9,
-            max_windows_per_option=16,
+            max_trials_per_option=16,
             max_decisions=20,
         )
         data.run()

--- a/tests/test_xdf_sources.py
+++ b/tests/test_xdf_sources.py
@@ -50,7 +50,7 @@ class TestXdfEegSource(unittest.TestCase):
         self.assertEqual(self.source.fsample, 256.0)
 
     def test_eeg_nchannel(self):
-        self.assertEqual(self.source.nchannels, 16)
+        self.assertEqual(self.source.num_channels, 16)
 
     def test_eeg_channel(self):
         self.assertEqual(len(self.source.channel_types), 16)
@@ -65,7 +65,7 @@ class TestXdfEegSource(unittest.TestCase):
         self.assertEqual(self.source.channel_labels[0], "FP1")
 
     def test_eeg_get_samples_provides_all_samples_in_one_go(self):
-        # first get is all the samples, ensure shape of array is: [n samples, nchannels]
+        # first get is all the samples, ensure shape of array is: [n samples, num_channels]
         samples, timestamps = self.source.get_samples()
         self.assertIsNotNone(samples)
         self.assertEqual(len(samples), 116992)

--- a/tests/test_xdf_sources.py
+++ b/tests/test_xdf_sources.py
@@ -50,7 +50,7 @@ class TestXdfEegSource(unittest.TestCase):
         self.assertEqual(self.source.fsample, 256.0)
 
     def test_eeg_nchannel(self):
-        self.assertEqual(self.source.num_channels, 16)
+        self.assertEqual(self.source.n_channels, 16)
 
     def test_eeg_channel(self):
         self.assertEqual(len(self.source.channel_types), 16)
@@ -65,7 +65,7 @@ class TestXdfEegSource(unittest.TestCase):
         self.assertEqual(self.source.channel_labels[0], "FP1")
 
     def test_eeg_get_samples_provides_all_samples_in_one_go(self):
-        # first get is all the samples, ensure shape of array is: [n samples, num_channels]
+        # first get is all the samples, ensure shape of array is: [n samples, n_channels]
         samples, timestamps = self.source.get_samples()
         self.assertIsNotNone(samples)
         self.assertEqual(len(samples), 116992)

--- a/tutorials/01_show_me_the_data.ipynb
+++ b/tutorials/01_show_me_the_data.ipynb
@@ -476,7 +476,7 @@
    ],
    "source": [
     "import numpy as np\n",
-    "# Open an interactive matplotlib window in the notebook\n",
+    "# Open an interactive matplotlib trial in the notebook\n",
     "%matplotlib widget\n",
     "\n",
     "# Plot the bandpass_filt_eeg again but with 50uV of offset between each channel\n",

--- a/tutorials/01_show_me_the_data.ipynb
+++ b/tutorials/01_show_me_the_data.ipynb
@@ -122,14 +122,14 @@
     "eeg_source = XdfEegSource(tutorial_data_filepath)\n",
     "\n",
     "[eeg_samples, eeg_timestamps] = eeg_source.get_samples()\n",
-    "nchannels = eeg_source.nchannels\n",
+    "num_channels = eeg_source.num_channels\n",
     "fsample = eeg_source.fsample\n",
     "channel_labels = eeg_source.channel_labels\n",
     "channel_types = eeg_source.channel_types\n",
     "channel_units = eeg_source.channel_units\n",
     "\n",
     "# Check that it worked by logging the channel labels and sampling rate\n",
-    "logger.info(\"The number of channels is: %s\", nchannels)\n",
+    "logger.info(\"The number of channels is: %s\", num_channels)\n",
     "logger.info(\"The sampling rate is: %s\", fsample)\n",
     "logger.info(\"The channel labels are: %s\", channel_labels)\n",
     "logger.info(\"The channel types are: %s\", channel_types)\n",
@@ -171,7 +171,7 @@
     "logger.info(\"The shape of the EEG timestamps is: %s\", raw_timestamps_shape)\n",
     "\n",
     "# Log the number of channels\n",
-    "logger.info(\"The number of channels is: %s\", nchannels)"
+    "logger.info(\"The number of channels is: %s\", num_channels)"
    ]
   },
   {

--- a/tutorials/01_show_me_the_data.ipynb
+++ b/tutorials/01_show_me_the_data.ipynb
@@ -122,14 +122,14 @@
     "eeg_source = XdfEegSource(tutorial_data_filepath)\n",
     "\n",
     "[eeg_samples, eeg_timestamps] = eeg_source.get_samples()\n",
-    "num_channels = eeg_source.num_channels\n",
+    "n_channels = eeg_source.n_channels\n",
     "fsample = eeg_source.fsample\n",
     "channel_labels = eeg_source.channel_labels\n",
     "channel_types = eeg_source.channel_types\n",
     "channel_units = eeg_source.channel_units\n",
     "\n",
     "# Check that it worked by logging the channel labels and sampling rate\n",
-    "logger.info(\"The number of channels is: %s\", num_channels)\n",
+    "logger.info(\"The number of channels is: %s\", n_channels)\n",
     "logger.info(\"The sampling rate is: %s\", fsample)\n",
     "logger.info(\"The channel labels are: %s\", channel_labels)\n",
     "logger.info(\"The channel types are: %s\", channel_types)\n",
@@ -171,7 +171,7 @@
     "logger.info(\"The shape of the EEG timestamps is: %s\", raw_timestamps_shape)\n",
     "\n",
     "# Log the number of channels\n",
-    "logger.info(\"The number of channels is: %s\", num_channels)"
+    "logger.info(\"The number of channels is: %s\", n_channels)"
    ]
   },
   {


### PR DESCRIPTION
For Jira task [B4K202](https://bci4kids.atlassian.net/browse/B4K-202)

**Important**: "windows" of eeg data now changed to "trials"

I've standardized references to the number of trials, channels and samples to the format `n_*` e.g. `n_trials`, `n_channels`, `n_samples`. These replace previous references to these values as `W_windows` (or `P`), `C_channels` (or `N`), `S_samples` (or `M`).

References to the number of decisions (often referred to with `P`) have been changed to `n_decisions`.

When referring to specific trial, channels or samples, such as looping through the number of trials (previously called windows) with `for win in range(windows)` or `for c in range(channels)`, I've replaced these abbreviations with the full variable. I.e. 
- `trial` instead of `p` or `w` or `win`
- `channel` instead of `n` or `c`
- `sample` instead of `m` or `s`
- `decision` instead of `p` or `d`

**Important**, I've changed references to the number of windows, channels and samples in the `EegData` object to be aligned with this naming scheme. I.e. in `EegData` (and objects based on it like `ErpData`
- `self.nwindows` is `self.n_trials`
- `self.nchannels` is `self.n_channels`
- `self.nsamples` is `self.n_samples`