### PR TITLE
Prediction backend fixes

### DIFF
--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -84,6 +84,10 @@ class BciController:
         self.__data_tank = data_tank
         self._messenger = messenger
 
+        # Initialize the event marker buffer
+        self.event_marker_buffer = []
+        self.event_timestamp_buffer = []
+
         self.headset_string = self.__eeg_source.name
         self.fsample = self.__eeg_source.fsample
         self.n_channels = self.__eeg_source.n_channels
@@ -378,10 +382,6 @@ class BciController:
         # read from sources to get new data. This puts command markers in the marker_data array and
         # event markers in the event_marker_strings array
         self._pull_data_from_sources()
-
-        # Initialize the event marker buffer
-        self.event_marker_buffer = []
-        self.event_timestamp_buffer = []
 
         # check if there is an available command marker, if not, break and wait for more data
         while len(self.marker_timestamps) > self.marker_count:

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -396,4 +396,18 @@ class ErpRgClassifier(GenericClassifier):
             Empty Predict object
 
         """
-        return Prediction()
+        proba_mat = self.clf.predict_proba(X)
+
+        proba = proba_mat[:, 1]
+        relative_proba = proba / np.amax(proba)
+
+        log_proba = np.log(relative_proba)
+        logger.info("log relative probabilities:\n%s", log_proba)
+
+        # the selection is the highest probability
+        prediction = int(np.where(proba == np.amax(proba))[0][0])
+
+        self.predictions.append(prediction)
+        self.pred_probas.append(proba_mat)
+
+        return Prediction(labels=prediction, probabilities=proba_mat)


### PR DESCRIPTION
1) buffer was being erased on every step... I don't think this should be the case as it was causing problems downstream with empty timestamp arrays, and it is already reset after `process_and_classify ` is called

2) `predict_decision_block `in `general_classifier `was commented out. This is because `bci_controller ` now calls `predict `instead of `predict_decision_block`. This is fine but `predict `does not have any code to return actual predictions. So I moved some `predict_decision_block `code to the `predict `method