### PR TITLE
Fix step thread blocking

### DIFF
--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -376,10 +376,6 @@ class BciController:
         # event markers in the event_marker_strings array
         self._pull_data_from_sources()
 
-        # # Initialize the event marker buffer
-        # self.event_marker_buffer = []
-        # self.event_timestamp_buffer = []
-
         # check if there is an available command marker, if not, break and wait for more data
         while len(self.marker_timestamps) > self.marker_count:
             # Get the current marker

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -337,6 +337,10 @@ class BciController:
         else:
             self.loops = 0
 
+        # Initialize the event marker buffer
+        self.event_marker_buffer = []
+        self.event_timestamp_buffer = []
+
         # start the main loop, stops after pulling new data, max_loops times
         while self.loops < max_loops:
             # print out loop status
@@ -372,9 +376,9 @@ class BciController:
         # event markers in the event_marker_strings array
         self._pull_data_from_sources()
 
-        # Initialize the event marker buffer
-        self.event_marker_buffer = []
-        self.event_timestamp_buffer = []
+        # # Initialize the event marker buffer
+        # self.event_marker_buffer = []
+        # self.event_timestamp_buffer = []
 
         # check if there is an available command marker, if not, break and wait for more data
         while len(self.marker_timestamps) > self.marker_count:

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -386,8 +386,6 @@ class BciController:
                 # send feedback for each marker that you receive
                 self._messenger.marker_received(current_step_marker)
 
-            logger.info("Marker: %s", current_step_marker)
-
             # If the marker contains a single string, then it is a command marker
             marker_is_single_string = len(current_step_marker.split(",")) == 1
             is_event_marker = not marker_is_single_string
@@ -449,4 +447,5 @@ class BciController:
                     self._classifier.fit()
                     self.train_complete = True
 
+            logger.info("Processed Marker: %s", current_step_marker)
             self.marker_count += 1

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -398,14 +398,16 @@ class ErpRgClassifier(GenericClassifier):
             the probability is only the posterior probability of the chosen object.
 
         """
-        
+
         n_epochs, n_channels, n_samples = X.shape
 
         # For each epoch get the posterior probability
         posterior_prob = np.zeros(n_epochs)
         for epoch in range(n_epochs):
             # Predict whether the epoch is target or non-target
-            posterior_prob[epoch] = self.clf.predict_proba(X[epoch, :, :].reshape(1, n_channels, n_samples))[0][1]
+            posterior_prob[epoch] = self.clf.predict_proba(
+                X[epoch, :, :].reshape(1, n_channels, n_samples)
+            )[0][1]
 
         label = [np.argmax(posterior_prob)]
         probability = [np.max(posterior_prob)]

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -388,12 +388,26 @@ class ErpRgClassifier(GenericClassifier):
         Parameters
         ----------
         X : numpy.ndarray
-            3D array where shape = (n_trials, n_channels, n_samples)
+            3D array where shape = (n_epochs, n_channels, n_samples)
 
         Returns
         -------
         prediction : Prediction
-            Empty Predict object
+            Predict object. Contains the predicted labels and and the probability.
+            Because this classifier chooses the P300 object with the highest posterior probability,
+            the probability is only the posterior probability of the chosen object.
 
         """
-        return Prediction()
+        
+        n_epochs, n_channels, n_samples = X.shape
+
+        # For each epoch get the posterior probability
+        posterior_prob = np.zeros(n_epochs)
+        for epoch in range(n_epochs):
+            # Predict whether the epoch is target or non-target
+            posterior_prob[epoch] = self.clf.predict_proba(X[epoch, :, :].reshape(1, n_channels, n_samples))[0][1]
+
+        label = [np.argmax(posterior_prob)]
+        probability = [np.max(posterior_prob)]
+
+        return Prediction(label, probability)

--- a/bci_essentials/paradigm/p300_paradigm.py
+++ b/bci_essentials/paradigm/p300_paradigm.py
@@ -108,7 +108,10 @@ class P300Paradigm(Paradigm):
 
         train_target = int(markers[3].split(",")[3])
         y = np.zeros(num_objects, dtype=int)
-        y[train_target] = 1
+        if train_target is not -1:
+            y[train_target] = 1
+        if train_target is -1: # Set all values of y to -1
+            y = np.full(num_objects, -1)
 
         flash_counts = np.zeros(num_objects)
 

--- a/bci_essentials/paradigm/p300_paradigm.py
+++ b/bci_essentials/paradigm/p300_paradigm.py
@@ -110,7 +110,7 @@ class P300Paradigm(Paradigm):
         y = np.zeros(num_objects, dtype=int)
         if train_target is not -1:
             y[train_target] = 1
-        if train_target is -1: # Set all values of y to -1
+        if train_target is -1:  # Set all values of y to -1
             y = np.full(num_objects, -1)
 
         flash_counts = np.zeros(num_objects)

--- a/bci_essentials/paradigm/ssvep_paradigm.py
+++ b/bci_essentials/paradigm/ssvep_paradigm.py
@@ -104,7 +104,7 @@ class SsvepParadigm(Paradigm):
             marker = marker.split(",")
             label = int(marker[2])
             epoch_length = float(marker[3])
-            self.flash_indices = [float(x) for x in marker[4:]]
+            self.target_freqs = [float(x) for x in marker[4:]]
 
             n_channels, _ = eeg.shape
 

--- a/examples/mi_unity_backend.py
+++ b/examples/mi_unity_backend.py
@@ -21,7 +21,7 @@ classifier.set_mi_classifier_settings(n_splits=3, type="TS", random_seed=35)
 
 # Define the MI data object
 mi_data = BciController(
-    classifier, eeg_source, marker_source, messenger, paradigm, data_tank
+    classifier, eeg_source, marker_source, paradigm, data_tank, messenger
 )
 
 # Run

--- a/examples/p300_unity_backend.py
+++ b/examples/p300_unity_backend.py
@@ -9,7 +9,6 @@ from bci_essentials.classification.erp_rg_classifier import ErpRgClassifier
 eeg_source = LslEegSource()
 marker_source = LslMarkerSource()
 messenger = LslMessenger()
-
 paradigm = P300Paradigm()
 data_tank = DataTank()
 
@@ -26,7 +25,7 @@ classifier.set_p300_clf_settings(
 )
 
 # Initialize the ERP
-test_erp = BciController(classifier, eeg_source, marker_source, messenger)
+test_erp = BciController(classifier, eeg_source, marker_source, paradigm, data_tank, messenger)
 
 # Run main
 test_erp.setup(

--- a/examples/p300_unity_backend.py
+++ b/examples/p300_unity_backend.py
@@ -25,7 +25,9 @@ classifier.set_p300_clf_settings(
 )
 
 # Initialize the ERP
-test_erp = BciController(classifier, eeg_source, marker_source, paradigm, data_tank, messenger)
+test_erp = BciController(
+    classifier, eeg_source, marker_source, paradigm, data_tank, messenger
+)
 
 # Run main
 test_erp.setup(

--- a/examples/ssvep_unity_backend.py
+++ b/examples/ssvep_unity_backend.py
@@ -23,7 +23,7 @@ classifier.set_ssvep_settings(
 
 # Initialize the data class
 test_ssvep = BciController(
-    classifier, eeg_source, marker_source, messenger, paradigm, data_tank
+    classifier, eeg_source, marker_source, paradigm, data_tank, messenger
 )
 
 # # Channel Selection

--- a/examples/ssvep_unity_backend.py
+++ b/examples/ssvep_unity_backend.py
@@ -26,14 +26,7 @@ test_ssvep = BciController(
     classifier, eeg_source, marker_source, paradigm, data_tank, messenger
 )
 
-classifier.target_freqs = [
-    7.857143,
-    9.705882,
-    12.69231,
-    15,
-    18.33333,
-    22
-]
+classifier.target_freqs = [7.857143, 9.705882, 12.69231, 15, 18.33333, 22]
 
 # # Channel Selection
 # initial_subset=[]

--- a/examples/ssvep_unity_backend.py
+++ b/examples/ssvep_unity_backend.py
@@ -26,6 +26,15 @@ test_ssvep = BciController(
     classifier, eeg_source, marker_source, paradigm, data_tank, messenger
 )
 
+classifier.target_freqs = [
+    7.857143,
+    9.705882,
+    12.69231,
+    15,
+    18.33333,
+    22
+]
+
 # # Channel Selection
 # initial_subset=[]
 # test_ssvep.classifier.setup_channel_selection(method = "SBFS", metric="accuracy", initial_channels = initial_subset,    # wrapper setup

--- a/examples/ssvep_unity_backend_tf.py
+++ b/examples/ssvep_unity_backend_tf.py
@@ -20,7 +20,7 @@ classifier = SsvepBasicTrainFreeClassifier()
 
 # Initialize the EEG Data
 test_ssvep = BciController(
-    classifier, eeg_source, marker_source, messenger, paradigm, data_tank
+    classifier, eeg_source, marker_source, paradigm, data_tank, messenger
 )
 
 # set train complete to true so that predictions will be allowed

--- a/examples/ssvep_unity_backend_tf.py
+++ b/examples/ssvep_unity_backend_tf.py
@@ -26,7 +26,14 @@ test_ssvep = BciController(
 # set train complete to true so that predictions will be allowed
 test_ssvep.train_complete = True
 
-target_freqs = [9, 9.6, 10.28, 11.07, 12, 13.09, 14.4]
+classifier.target_freqs = [
+    7.857143,
+    9.705882,
+    12.69231,
+    15,
+    18.33333,
+    22
+]
 
 # Run
 test_ssvep.setup(online=True)

--- a/examples/ssvep_unity_backend_tf.py
+++ b/examples/ssvep_unity_backend_tf.py
@@ -26,14 +26,7 @@ test_ssvep = BciController(
 # set train complete to true so that predictions will be allowed
 test_ssvep.train_complete = True
 
-classifier.target_freqs = [
-    7.857143,
-    9.705882,
-    12.69231,
-    15,
-    18.33333,
-    22
-]
+classifier.target_freqs = [7.857143, 9.705882, 12.69231, 15, 18.33333, 22]
 
 # Run
 test_ssvep.setup(online=True)

--- a/tests/test_eeg_data.py
+++ b/tests/test_eeg_data.py
@@ -103,15 +103,11 @@ class TestBciController(unittest.TestCase):
         data.step()
 
         # Add some fake EEG data
-        data_tank.add_raw_eeg(
-                np.array([1, 2, 3]), np.array([0, 1, 2])
-            )
+        data_tank.add_raw_eeg(np.array([1, 2, 3]), np.array([0, 1, 2]))
 
         # Add a marker for which we have no data
-        data_tank.add_raw_markers(
-                np.array(["mi,2,-1,0.5"]), np.array([100])  
-            )
-        
+        data_tank.add_raw_markers(np.array(["mi,2,-1,0.5"]), np.array([100]))
+
         # Run another step, it should not wait for more data (< 1s)
         start = time.time()
         data.step()

--- a/tests/test_eeg_data.py
+++ b/tests/test_eeg_data.py
@@ -1,5 +1,8 @@
 import unittest
 
+import numpy as np
+import time
+
 from bci_essentials.io.sources import MarkerSource, EegSource
 from bci_essentials.io.messenger import Messenger
 
@@ -84,6 +87,37 @@ class TestBciController(unittest.TestCase):
         self.assertEqual(self.messenger.ping_count, 1)
         data.step()
         self.assertEqual(self.messenger.ping_count, 2)
+
+    def test_step_does_not_wait_for_more_data(self):
+        data_tank = DataTank()
+
+        data = BciController(
+            self.classifier,
+            self.eeg,
+            self.markers,
+            MiParadigm(),
+            data_tank,
+            self.messenger,
+        )
+        data.setup(online=True)
+        data.step()
+
+        # Add some fake EEG data
+        data_tank.add_raw_eeg(
+                np.array([1, 2, 3]), np.array([0, 1, 2])
+            )
+
+        # Add a marker for which we have no data
+        data_tank.add_raw_markers(
+                np.array(["mi,2,-1,0.5"]), np.array([100])  
+            )
+        
+        # Run another step, it should not wait for more data (< 1s)
+        start = time.time()
+        data.step()
+        end = time.time()
+
+        self.assertLess(end - start, 1)
 
     def test_when_online_and_invalid_markers_then_loop_continues(self):
         data = BciController(


### PR DESCRIPTION
The issue here was that step() was waiting for the EEG to process the markers it had in the buffer instead of breaking and waiting for the next step. This is changed now, so that __process_and_classify() returns a False if it was unable to complete and step() knows to quit. This does not remove the marker from the marker buffer, so no markers are lost. 

I wrote a test for this, which basically just adds so fake EEG and EEG timestamps and a marker to the data_tank. The marker timestamp is greater than any EEG timestamps, so in the old config, this would cause step to hang while it waits for more data. Now it just breaks from the step. This quick breaking is just measured by a timer, where a step time less than 1 s assumes no hanging.

In the process of testing online with Bessy Unity I found that there was actually no predictions happening from P300 (oops). And that the online SSVEP examples had some incorrect syntax. These issues are both fixed too.