### PR TITLE
Fixed the channel selection P300

### DIFF
--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -351,9 +351,7 @@ class ErpRgClassifier(GenericClassifier):
             logger.warning("Not doing channel selection")
             X = self.get_subset(self.X, self.subset, self.channel_labels)
 
-            self.clf, preds, accuracy, precision, recall = __erp_rg_kernel(
-                X, self.y
-            )
+            self.clf, preds, accuracy, precision, recall = __erp_rg_kernel(X, self.y)
 
         # Log performance stats
         # accuracy

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -349,8 +349,10 @@ class ErpRgClassifier(GenericClassifier):
             self.clf = updated_model
         else:
             logger.warning("Not doing channel selection")
+            X = self.get_subset(self.X, self.subset, self.channel_labels)
+
             self.clf, preds, accuracy, precision, recall = __erp_rg_kernel(
-                self.X, self.y
+                X, self.y
             )
 
         # Log performance stats

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -345,6 +345,7 @@ class ErpRgClassifier(GenericClassifier):
 
             self.results_df = results_df
             self.subset = updated_subset
+            self.subset_defined = True
             self.clf = updated_model
         else:
             logger.warning("Not doing channel selection")
@@ -399,15 +400,10 @@ class ErpRgClassifier(GenericClassifier):
 
         """
 
-        n_epochs, n_channels, n_samples = X.shape
+        subset_X = self.get_subset(X, self.subset, self.channel_labels)
 
-        # For each epoch get the posterior probability
-        posterior_prob = np.zeros(n_epochs)
-        for epoch in range(n_epochs):
-            # Predict whether the epoch is target or non-target
-            posterior_prob[epoch] = self.clf.predict_proba(
-                X[epoch, :, :].reshape(1, n_channels, n_samples)
-            )[0][1]
+        # Get posterior probability for each target
+        posterior_prob = self.clf.predict_proba(subset_X)[:, 1]
 
         label = [np.argmax(posterior_prob)]
         probability = [np.max(posterior_prob)]

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -405,7 +405,7 @@ class ErpRgClassifier(GenericClassifier):
         # Get posterior probability for each target
         posterior_prob = self.clf.predict_proba(subset_X)[:, 1]
 
-        label = [np.argmax(posterior_prob)]
+        label = [int(np.argmax(posterior_prob))]
         probability = [np.max(posterior_prob)]
 
         return Prediction(label, probability)

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -179,6 +179,7 @@ class GenericClassifier(ABC):
                 logger.info("Using subset indices")
 
                 subset_indices = self.subset
+                self.subset_defined
 
             # Or channel labels
             if type(self.subset[0]) is str:
@@ -188,6 +189,7 @@ class GenericClassifier(ABC):
                 for sl in self.subset:
                     subset_indices.append(self.channel_labels.index(sl))
 
+                self.subset_defined = True
             # Return for the given indices
             try:
                 if sum(X.shape) == 0:

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -322,7 +322,7 @@ class MiClassifier(GenericClassifier):
             subset_X
         )
 
-        pred = self.clf.predict(cov_subset_X)
+        pred = [int(x) for x in self.clf.predict(cov_subset_X)]
         pred_proba = self.clf.predict_proba(cov_subset_X)
 
         logger.info("Prediction: %s", pred)

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -265,6 +265,9 @@ class MiClassifier(GenericClassifier):
             self.clf = updated_model
         else:
             logger.warning("Not doing channel selection")
+
+            subX = self.get_subset(subX, self.subset, self.channel_labels)
+
             self.clf, preds, accuracy, precision, recall = __mi_kernel(subX, suby)
 
         # Log performance stats

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -261,6 +261,7 @@ class MiClassifier(GenericClassifier):
 
             self.results_df = results_df
             self.subset = updated_subset
+            self.subset_defined = True
             self.clf = updated_model
         else:
             logger.warning("Not doing channel selection")

--- a/bci_essentials/paradigm/p300_paradigm.py
+++ b/bci_essentials/paradigm/p300_paradigm.py
@@ -106,7 +106,7 @@ class P300Paradigm(Paradigm):
         n_channels, _ = eeg.shape
         num_objects = int(markers[0].split(",")[2])
 
-        train_target = int(markers[3].split(",")[3])
+        train_target = int(markers[0].split(",")[3])
         y = np.zeros(num_objects, dtype=int)
         if train_target is not -1:
             y[train_target] = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bci-essentials"
-version = "0.2.1"
+version = "0.2.2"
 description = "Python backend for bci-essentials"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
The channel subsets chosen by the channel selection method weren't being used for online classification.

This also simplifies the calculation of posterior probabilities from epochs.

This was tested with p300_offline_test.py and the debugger to ensure subsets were being used.