### PR TITLE
Paradigm variable in LSL sim

### DIFF
--- a/examples/eeg_lsl_sim.py
+++ b/examples/eeg_lsl_sim.py
@@ -76,7 +76,14 @@ eeg_timestamps = eeg_timestamps[tuple(eeg_keep_ind)]
 bci_controller = bci_controller[tuple(eeg_keep_ind)]
 
 # create the eeg stream
-info = StreamInfo("MockEEG", "EEG", eeg_source.n_channels, eeg_source.fsample, "float32", "mockeeg1")
+info = StreamInfo(
+    "MockEEG",
+    "EEG",
+    eeg_source.n_channels,
+    eeg_source.fsample,
+    "float32",
+    "mockeeg1"
+)
 
 # add channel data
 channels = info.desc().append_child("channels")

--- a/examples/eeg_lsl_sim.py
+++ b/examples/eeg_lsl_sim.py
@@ -82,7 +82,7 @@ info = StreamInfo(
     eeg_source.n_channels,
     round(eeg_source.fsample),
     "float32",
-    "mockeeg1"
+    "mockeeg1",
 )
 
 # add channel data

--- a/examples/eeg_lsl_sim.py
+++ b/examples/eeg_lsl_sim.py
@@ -6,6 +6,7 @@ EEG LSL sim simulates offline EEG data as online data
 Additional Arguments:
 now (-n)            -   start the stream immediately
 num_loops (int)     -   number of times to repeat the stream
+paradigm (str)      -   paradigm to simulate (p300 (default), ssvep, mi)
 
 ex.
 >python eeg_lsl_sim.py now 8
@@ -26,13 +27,18 @@ from pylsl import StreamInfo, StreamOutlet
 from bci_essentials.io.xdf_sources import XdfEegSource, XdfMarkerSource
 from bci_essentials.utils.logger import Logger  # Logger wrapper
 
+try:
+    paradigm = sys.argv[3]
+except IndexError:
+    paradigm = "p300"  # Default value
+
 # Instantiate a logger for the module at the default level of logging.INFO
 logger = Logger(name="eeg_lsl_sim")
 
 # Identify the file to simulate
 # Filename assumes the data is within a subfolder called "data" located
 # within the same folder as this script
-filename = os.path.join("data", "p300_example.xdf")
+filename = os.path.join("data", f"{paradigm}_example.xdf")
 
 # Check whether to start now, or at the next even minute to sync with other programs
 start_now = False
@@ -69,12 +75,8 @@ eeg_keep_ind = [(eeg_timestamps > time_start) & (eeg_timestamps < time_stop)]
 eeg_timestamps = eeg_timestamps[tuple(eeg_keep_ind)]
 bci_controller = bci_controller[tuple(eeg_keep_ind)]
 
-# estimate sampling rates
-fs_marker = round(len(marker_timestamps) / (time_stop - time_start))
-fs_eeg = round(len(eeg_timestamps) / (time_stop - time_start))
-
 # create the eeg stream
-info = StreamInfo("MockEEG", "EEG", 8, fs_eeg, "float32", "mockeeg1")
+info = StreamInfo("MockEEG", "EEG", eeg_source.n_channels, eeg_source.fsample, "float32", "mockeeg1")
 
 # add channel data
 channels = info.desc().append_child("channels")

--- a/examples/eeg_lsl_sim.py
+++ b/examples/eeg_lsl_sim.py
@@ -80,7 +80,7 @@ info = StreamInfo(
     "MockEEG",
     "EEG",
     eeg_source.n_channels,
-    eeg_source.fsample,
+    round(eeg_source.fsample),
     "float32",
     "mockeeg1"
 )


### PR DESCRIPTION
# Changes
- Added a paradigm variable (default: p300) to automatically select the file used to create the simulated LSL stream
- Changed hardcoded value for number of channels since that depends on the file selected
- Removed calculation of the sampling frequency since that value is stored on `eeg_source` 

# Testing
- Open an Anaconda terminal with the `BCI` environment activated, and run:
``` 
python Examples/eeg_lsl.sim.py -n 8 type 
```

- Modify `type` to be `p300`, `ssvep`, or `mi` to change the selected stream, or leave `type` empty to stream the `p300` file.