### PR TITLE
Improve channel selection

### DIFF
--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -97,7 +97,6 @@ def channel_selection_by_method(
     preds : numpy.ndarray
         The predictions from the model.
         1D array with the same shape as `y`.
-
         shape = (`n_trials`)
     accuracy : float
         The accuracy of the trained classification model.
@@ -206,6 +205,7 @@ def channel_selection_by_method(
 
 
 def __check_stopping_criterion(
+    algorithm,
     current_time,
     n_channels,
     current_performance_delta,
@@ -218,6 +218,8 @@ def __check_stopping_criterion(
 
     Parameters
     ----------
+    algorithm : str
+        The algorithm being used for channel selection.
     current_time : float
         The time elapsed since the start of the channel selection method.
     n_channels : int
@@ -246,19 +248,21 @@ def __check_stopping_criterion(
         logger.debug("Stopping based on time")
         return True
 
-    elif n_channels <= min_channels:
-        logger.debug("Stopping because minimum number of channels reached")
-        return True
+    if algorithm == "SBS" or algorithm == "SBFS":
+        if n_channels <= min_channels:
+            logger.debug("Stopping because minimum number of channels reached")
+            return True
 
-    elif n_channels >= max_channels:
-        logger.debug("Stopping because maximum number of channels reached")
-        return True
+    if algorithm == "SFS" or algorithm == "SFFS":
+        if n_channels >= max_channels:
+            logger.debug("Stopping because maximum number of channels reached")
+            return True
 
-    elif current_performance_delta < performance_delta:
+    if current_performance_delta < performance_delta:
         logger.debug("Stopping because performance improvements are declining")
         return True
-    else:
-        return False
+    
+    return False
 
 
 def __sfs(
@@ -508,6 +512,7 @@ def __sfs(
         step += 1
 
         stop_criterion = __check_stopping_criterion(
+            "SFS",
             time.time() - start_time,
             len(new_channel_subset),
             p_delta,
@@ -784,11 +789,12 @@ def __sbs(
 
         step += 1
 
-        # Break if SBFS subset is 1 channel
+        # Break if SBS subset is 1 channel
         if len(sbs_subset) == 1:
             break
 
         stop_criterion = __check_stopping_criterion(
+            "SBS",
             time.time() - start_time,
             len(new_channel_subset),
             p_delta,
@@ -1229,6 +1235,7 @@ def __sbfs(
 
             # Check stopping criterion
             stop_criterion = __check_stopping_criterion(
+                "SBFS",
                 time.time() - start_time,
                 len(new_channel_subset),
                 p_delta,
@@ -1239,6 +1246,7 @@ def __sbfs(
             )
 
         stop_criterion = __check_stopping_criterion(
+            "SBFS",
             time.time() - start_time,
             len(new_channel_subset),
             p_delta,
@@ -1678,6 +1686,7 @@ def __sffs(
             # Check stopping criterion
             if pass_stopping_criterion is False:
                 stop_criterion = __check_stopping_criterion(
+                    "SFFS",
                     time.time() - start_time,
                     len(new_channel_subset),
                     p_delta,
@@ -1692,6 +1701,7 @@ def __sffs(
             continue
         else:
             stop_criterion = __check_stopping_criterion(
+                "SFFS",
                 time.time() - start_time,
                 len(new_channel_subset),
                 p_delta,

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -496,18 +496,17 @@ def __sfs(
             best_precision = precision
             best_recall = recall
 
-        if record_performance is True:
-            new_channel_subset.sort()
-            results_df.loc[step] = [
-                step,
-                time.time() - start_time,
-                len(new_channel_subset),
-                "".join(new_channel_subset),
-                len(sets_to_try),
-                accuracy,
-                precision,
-                recall,
-            ]
+        new_channel_subset.sort()
+        results_df.loc[step] = [
+            step,
+            time.time() - start_time,
+            len(new_channel_subset),
+            "".join(new_channel_subset),
+            len(sets_to_try),
+            accuracy,
+            precision,
+            recall,
+        ]
 
         step += 1
 
@@ -527,6 +526,9 @@ def __sfs(
     logger.debug("Best channel subset: %s", best_channel_subset)
     logger.debug("%s : %s", metric, best_performance)
     logger.debug("Time to optimal subset: %s s", time.time() - start_time)
+
+    if record_performance is True:
+        print(results_df)
 
     # Get the best model
 
@@ -774,18 +776,17 @@ def __sbs(
             best_precision = precision
             best_recall = recall
 
-        if record_performance is True:
-            new_channel_subset.sort()
-            results_df.loc[step] = [
-                step,
-                time.time() - start_time,
-                len(new_channel_subset),
-                "".join(new_channel_subset),
-                len(sets_to_try),
-                accuracy,
-                precision,
-                recall,
-            ]
+        new_channel_subset.sort()
+        results_df.loc[step] = [
+            step,
+            time.time() - start_time,
+            len(new_channel_subset),
+            "".join(new_channel_subset),
+            len(sets_to_try),
+            accuracy,
+            precision,
+            recall,
+        ]
 
         step += 1
 
@@ -809,6 +810,9 @@ def __sbs(
     logger.debug("Best channel subset: %s", best_channel_subset)
     logger.debug("%s : %s", metric, best_performance)
     logger.debug("Time to optimal subset: %s s", time.time() - start_time)
+
+    if record_performance is True:
+        print(results_df)
 
     return (
         best_channel_subset,
@@ -1210,19 +1214,18 @@ def __sbfs(
                     best_precision = precision
                     best_recall = recall
 
-                if record_performance:
-                    new_channel_subset.sort()
-                    results_df.loc[step] = [
-                        step,
-                        time.time() - start_time,
-                        len(new_channel_subset),
-                        "".join(new_channel_subset),
-                        len(sets_to_try),
-                        accuracy,
-                        precision,
-                        recall,
-                    ]
-                    step += 1
+                new_channel_subset.sort()
+                results_df.loc[step] = [
+                    step,
+                    time.time() - start_time,
+                    len(new_channel_subset),
+                    "".join(new_channel_subset),
+                    len(sets_to_try),
+                    accuracy,
+                    precision,
+                    recall,
+                ]
+                step += 1
 
                 performance_at_n_channels[length_of_resultant_set - 1] = (
                     current_performance
@@ -1265,6 +1268,9 @@ def __sbfs(
     logger.debug("Best channel subset: %s", best_channel_subset)
     logger.debug("%s : %s", metric, best_performance)
     logger.debug("Time to optimal subset: %s s", time.time() - start_time)
+
+    if record_performance is True:
+        print(results_df)
 
     return (
         best_channel_subset,
@@ -1525,18 +1531,17 @@ def __sffs(
             best_precision = precision
             best_recall = recall
 
-        if record_performance:
-            new_channel_subset.sort()
-            results_df.loc[step] = [
-                step,
-                time.time() - start_time,
-                len(new_channel_subset),
-                "".join(new_channel_subset),
-                len(sets_to_try),
-                accuracy,
-                precision,
-                recall,
-            ]
+        new_channel_subset.sort()
+        results_df.loc[step] = [
+            step,
+            time.time() - start_time,
+            len(new_channel_subset),
+            "".join(new_channel_subset),
+            len(sets_to_try),
+            accuracy,
+            precision,
+            recall,
+        ]
 
         step += 1
 
@@ -1716,6 +1721,9 @@ def __sffs(
     logger.debug("Best channel subset: %s", best_channel_subset)
     logger.debug("%s : %s", metric, best_performance)
     logger.debug("Time to optimal subset: %s s", time.time() - start_time)
+
+    if record_performance is True:
+        print(results_df)
 
     return (
         best_channel_subset,

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -410,7 +410,7 @@ def __sfs(
         for channel in range(n_channels):
             if channel not in sfs_subset:
                 set_to_try = sfs_subset.copy()
-                set_to_try.append(c)
+                set_to_try.append(channel)
                 sets_to_try.append(set_to_try)
 
                 # Get the new subset of data
@@ -677,9 +677,9 @@ def __sbs(
         # Exclusion Step
         sets_to_try = []
         X_to_try = []
-        for c in sbs_subset:
+        for channel in sbs_subset:
             set_to_try = sbs_subset.copy()
-            set_to_try.remove(c)
+            set_to_try.remove(channel)
             set_to_try.sort()
 
             # Only try sets that have not been tried before

--- a/examples/mi_ch_select_test.py
+++ b/examples/mi_ch_select_test.py
@@ -36,7 +36,7 @@ classifier.set_mi_classifier_settings(n_splits=5, type="TS", random_seed=35)
 # Define channel selection settings
 initial_subset = []
 classifier.setup_channel_selection(
-    method="SFFS",
+    method="SBFS",
     metric="accuracy",
     iterative_selection=True,
     initial_channels=initial_subset,  # wrapper setup

--- a/examples/mi_unity_backend.py
+++ b/examples/mi_unity_backend.py
@@ -19,6 +19,21 @@ classifier = MiClassifier()  # you can add a subset here
 # Set settings
 classifier.set_mi_classifier_settings(n_splits=3, type="TS", random_seed=35)
 
+# Define channel selection settings
+initial_subset = []
+classifier.setup_channel_selection(
+    method="SFS",
+    metric="accuracy",
+    iterative_selection=True,
+    initial_channels=initial_subset,  # wrapper setup
+    max_time=4,
+    min_channels=0,
+    max_channels=20,
+    performance_delta=-0.05,  # stopping criterion
+    n_jobs=-1,
+    record_performance=True,
+)
+
 # Define the MI data object
 mi_data = BciController(
     classifier, eeg_source, marker_source, paradigm, data_tank, messenger

--- a/examples/mi_unity_backend.py
+++ b/examples/mi_unity_backend.py
@@ -24,12 +24,12 @@ initial_subset = []
 classifier.setup_channel_selection(
     method="SFS",
     metric="accuracy",
-    iterative_selection=True,
+    iterative_selection=False,
     initial_channels=initial_subset,  # wrapper setup
-    max_time=4,
+    max_time=100,
     min_channels=0,
-    max_channels=20,
-    performance_delta=-0.05,  # stopping criterion
+    max_channels=4,
+    performance_delta=-1,  # stopping criterion
     n_jobs=-1,
     record_performance=True,
 )

--- a/tests/test_channel_selection.py
+++ b/tests/test_channel_selection.py
@@ -36,20 +36,18 @@ logger = Logger(name="test_channel_selection")
 # Create the ideal signal
 fs = 128
 t = np.arange(0, 1, 1 / fs)
-ideal_signal = np.sin(2 * np.pi * 8 * t)
-
-# Create the noise
-np.random.seed(0)
-noise = np.random.normal(0, 0.1, len(t))
-
-# Create the noisy signal
-noisy_signal = ideal_signal + noise
 
 import matplotlib.pyplot as plt
 # Create epochs of 
 
 X = np.zeros((10, 10, len(t)))
 y = np.zeros(10)
+
+# Create a spline
+trend = [(0.01 * (-0.08*s +2.0)**3.0) + (0.05 * s) + 1.0 for s in range(1,129)]
+
+
+
 
 channel_labels = ["ch" + str(i) for i in range(1,11)]
 
@@ -58,32 +56,33 @@ for i in range(10):
         if i % 2 == 0:
             y[i] = 0
 
-            ideal_signal = np.sin(2 * np.pi * 9 * t)
+            ideal_signal = np.sin(2 * np.pi * 8 * t)
             signal = ideal_signal + np.random.normal(0, 2, len(t))
             for k in range(j):
-                signal += 5 * np.random.normal(0, 2, len(t))
+                signal += np.random.normal(0, 2, len(t))
 
             X[i, j, :] = signal
 
         else:
             y[i] = 1
 
-            ideal_signal = np.sin(2 * np.pi * 8 * t)
+            ideal_signal = np.sin(2 * np.pi * 8 * t) * trend
             signal = ideal_signal + np.random.normal(0, 2, len(t))
             for k in range(j):
-                signal += 5 * np.random.normal(0, 2, len(t))
+                signal += np.random.normal(0, 2, len(t))
 
             X[i, j, :] = signal
 
 # # Plot the first 10 epochs
 # for i in range(10):
-#     plt.plot(t, X[0, i, :] + i*2)
+#     plt.plot(t, X[1, i, :] + i*20)
 
+# plt.legend(channel_labels)
 # plt.show()
 
 
-def test_kernel(subX, suby):
-        """Test kernel.
+def _test_kernel(subX, suby):
+        """Test kernel for channel selection.
 
         Parameters
         ----------
@@ -150,11 +149,11 @@ class TestChannelSelection(unittest.TestCase):
     def test_sfs(self):
         # Test SFS
         selected_channels = channel_selection_by_method(
-            kernel_func = test_kernel, 
+            kernel_func = _test_kernel, 
             X = X, 
             y = y, 
             channel_labels = channel_labels,
-            method="SBS", 
+            method="SFS", 
             initial_channels=[],
             max_time=999,
             min_channels=0,

--- a/tests/test_channel_selection.py
+++ b/tests/test_channel_selection.py
@@ -1,0 +1,311 @@
+import unittest
+import os
+import numpy as np
+
+from bci_essentials.io.xdf_sources import XdfMarkerSource, XdfEegSource
+from bci_essentials.bci_controller import BciController
+from bci_essentials.paradigm.mi_paradigm import MiParadigm
+from bci_essentials.paradigm.p300_paradigm import P300Paradigm
+from bci_essentials.paradigm.ssvep_paradigm import SsvepParadigm
+from bci_essentials.data_tank.data_tank import DataTank
+from bci_essentials.classification.mi_classifier import MiClassifier
+from bci_essentials.classification.erp_rg_classifier import ErpRgClassifier
+from bci_essentials.classification.ssvep_riemannian_mdm_classifier import (
+    SsvepRiemannianMdmClassifier,
+)
+from bci_essentials.utils.logger import Logger  # Logger wrapper
+from bci_essentials.channel_selection import channel_selection_by_method
+
+
+import numpy as np
+from sklearn.model_selection import StratifiedKFold
+from sklearn.pipeline import Pipeline
+from sklearn.metrics import precision_score, recall_score
+from pyriemann.estimation import Covariances
+from pyriemann.classification import MDM
+
+
+# Instantiate a logger for the module at the default level of logging.INFO
+logger = Logger(name="test_channel_selection")
+
+# Tests channel selection using 10 channels, with growing amounts of noise
+# First create an ideal signal, a sinusoid with frequency 8 Hz and amplitude 1
+# Then add noise to the signal, with increasing standard deviation
+# Finally, test the channel selection algorithm on the noisy signal
+
+# Create the ideal signal
+fs = 128
+t = np.arange(0, 1, 1 / fs)
+ideal_signal = np.sin(2 * np.pi * 8 * t)
+
+# Create the noise
+np.random.seed(0)
+noise = np.random.normal(0, 0.1, len(t))
+
+# Create the noisy signal
+noisy_signal = ideal_signal + noise
+
+import matplotlib.pyplot as plt
+# Create epochs of 
+
+X = np.zeros((10, 10, len(t)))
+y = np.zeros(10)
+
+channel_labels = ["ch" + str(i) for i in range(1,11)]
+
+for i in range(10):
+    for j in range(10):
+        if i % 2 == 0:
+            y[i] = 0
+
+            ideal_signal = np.sin(2 * np.pi * 9 * t)
+            signal = ideal_signal + np.random.normal(0, 2, len(t))
+            for k in range(j):
+                signal += 5 * np.random.normal(0, 2, len(t))
+
+            X[i, j, :] = signal
+
+        else:
+            y[i] = 1
+
+            ideal_signal = np.sin(2 * np.pi * 8 * t)
+            signal = ideal_signal + np.random.normal(0, 2, len(t))
+            for k in range(j):
+                signal += 5 * np.random.normal(0, 2, len(t))
+
+            X[i, j, :] = signal
+
+# # Plot the first 10 epochs
+# for i in range(10):
+#     plt.plot(t, X[0, i, :] + i*2)
+
+# plt.show()
+
+
+def test_kernel(subX, suby):
+        """Test kernel.
+
+        Parameters
+        ----------
+        subX : numpy.ndarray
+            EEG data for training.
+            3D array with shape = (`n_epochs`, `n_channels`, `n_samples`).
+        suby : numpy.ndarray
+            Labels for training data.
+            1D array with shape = (`n_epochs`, ).
+
+        Returns
+        -------
+        model : classifier
+            The trained classification model.
+        preds : numpy.ndarray
+            The predictions from the model.
+            1D array with the same shape as `suby`.
+        accuracy : float
+            The accuracy of the trained classification model.
+        precision : float
+            The precision of the trained classification model.
+        recall : float
+            The recall of the trained classification model.
+
+        """
+        n_splits = 5
+        cv = StratifiedKFold(
+            n_splits=n_splits, shuffle=True, random_state=42
+        )
+
+        mdm = MDM(metric=dict(mean="riemann", distance="riemann"))
+        clf_model = Pipeline([("MDM", mdm)])
+
+        preds = np.zeros_like(suby)
+
+
+        for train_idx, test_idx in cv.split(subX, suby):
+            clf = clf_model
+
+            X_train, X_test = subX[train_idx], subX[test_idx]
+            # y_test not implemented
+            y_train = suby[train_idx]
+
+            # get the covariance matrices for the training set
+            X_train_cov = Covariances().transform(X_train)
+            X_test_cov = Covariances().transform(X_test)
+
+            # fit the classsifier
+            clf.fit(X_train_cov, y_train)
+            preds[test_idx] = clf.predict(X_test_cov)
+
+        accuracy = sum(preds == suby) / len(preds)
+        precision = precision_score(suby, preds, average="micro")
+        recall = recall_score(suby, preds, average="micro")
+
+        model = clf
+
+        return model, preds, accuracy, precision, recall
+
+
+
+
+class TestChannelSelection(unittest.TestCase):
+    def test_sfs(self):
+        # Test SFS
+        selected_channels = channel_selection_by_method(
+            kernel_func = test_kernel, 
+            X = X, 
+            y = y, 
+            channel_labels = channel_labels,
+            method="SBS", 
+            initial_channels=[],
+            max_time=999,
+            min_channels=0,
+            max_channels=20, 
+            performance_delta=-1,
+            n_jobs=-1, 
+            record_performance=True
+        )
+        
+        print(selected_channels)
+
+        self.assertEqual(len(selected_channels), 5)
+
+
+
+
+#         # Get the MI example data from ./examples/data
+#         xdf_path = os.path.join(os.path.dirname(__file__), "data", "mi_smoke.xdf")
+#         eeg_source = XdfEegSource(xdf_path)
+#         marker_source = XdfMarkerSource(xdf_path)
+
+#         paradigm = MiParadigm(live_update=True, iterative_training=False)
+#         data_tank = DataTank()
+
+#         # Select a classifier
+#         classifier = MiClassifier()
+#         classifier.set_mi_classifier_settings(
+#             n_splits=5, type="TS", random_seed=35, channel_selection="riemann"
+#         )
+
+#         # Load the data
+#         data = BciController(classifier, eeg_source, marker_source, paradigm, data_tank)
+
+#         # Run main loop, this will do all of the classification for online or offline
+#         data.setup(
+#             online=False,
+#         )
+#         data.run()
+
+#         # Check that a model was trained
+#         self.assertIsNotNone(classifier.clf)
+
+#         # Check that accuracy, precision, recall and covariance matrix exist
+#         self.assertIsNotNone(classifier.offline_accuracy)
+#         self.assertIsNotNone(classifier.offline_precision)
+#         self.assertIsNotNone(classifier.offline_recall)
+#         self.assertIsNotNone(classifier.offline_cm)
+
+#         # Check that the list of class predictions exists
+#         self.assertIsNotNone(classifier.predictions)
+
+#         logger.info("MI test complete")
+
+#     def test_p300_offline(self):
+#         # Get the P300 example data from ./examples/data
+#         xdf_path = os.path.join(os.path.dirname(__file__), "data", "p300_smoke.xdf")
+#         eeg_source = XdfEegSource(xdf_path)
+#         marker_source = XdfMarkerSource(xdf_path)
+
+#         paradigm = P300Paradigm()
+#         data_tank = DataTank()
+
+#         # Select a classifier
+#         classifier = ErpRgClassifier()
+#         classifier.set_p300_clf_settings(
+#             n_splits=5,
+#             lico_expansion_factor=4,
+#             oversample_ratio=0,
+#             undersample_ratio=0,
+#             random_seed=35,
+#         )
+
+#         # Load the data
+#         data = BciController(classifier, eeg_source, marker_source, paradigm, data_tank)
+
+#         # Run main loop, this will do all of the classification for online or offline
+#         data.setup(
+#             online=False,
+#         )
+#         data.run()
+
+#         # Check that a model was trained
+#         self.assertIsNotNone(classifier.clf)
+
+#         # Check that accuracy, precision, recall and covariance matrix exist
+#         self.assertIsNotNone(classifier.offline_accuracy)
+#         self.assertIsNotNone(classifier.offline_precision)
+#         self.assertIsNotNone(classifier.offline_recall)
+#         self.assertIsNotNone(classifier.offline_cm)
+
+#         # Check that the list of class predictions exists
+#         self.assertIsNotNone(classifier.predictions)
+
+#         logger.info("P300 test complete")
+
+#     def test_ssvep_offline(self):
+#         # Get the SSVEP example data from ./examples/data
+#         xdf_path = os.path.join(os.path.dirname(__file__), "data", "ssvep_smoke.xdf")
+#         eeg_source = XdfEegSource(xdf_path)
+#         marker_source = XdfMarkerSource(xdf_path)
+
+#         paradigm = SsvepParadigm()
+#         data_tank = DataTank()
+
+#         # Select a classifier
+#         classifier = SsvepRiemannianMdmClassifier()
+#         classifier.set_ssvep_settings(
+#             n_splits=3,
+#             random_seed=35,
+#             n_harmonics=2,
+#             f_width=0.2,
+#             covariance_estimator="scm",
+#         )
+#         classifier.target_freqs = [
+#             24,
+#             20.57143,
+#             18,
+#             16,
+#             14.4,
+#             12,
+#             10.28571,
+#             9,
+#             8,
+#             7.2,
+#             6,
+#             4.965517,
+#         ]
+
+#         # Load the data
+#         data = BciController(classifier, eeg_source, marker_source, paradigm, data_tank)
+
+#         # Run main loop, this will do all of the classification for online or offline
+#         data.setup(
+#             online=False,
+#         )
+#         data.run()
+
+#         # Check that a model was trained
+#         self.assertIsNotNone(classifier.clf)
+
+#         # Check that accuracy, precision, recall and covariance matrix exist
+#         self.assertIsNotNone(classifier.offline_accuracy)
+#         self.assertIsNotNone(classifier.offline_precision)
+#         self.assertIsNotNone(classifier.offline_recall)
+#         self.assertIsNotNone(classifier.offline_cm)
+
+#         # Check that the list of class predictions exists
+#         self.assertIsNotNone(classifier.predictions)
+
+#         logger.info("SSVEP test complete")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds tests for channel selection. I also confirmed that it is working online.

To test online, use real or mock EEG data and an instance of Bessy Unity (I used MI), run mi_unity_backend.py and confirm that after training, when you hit "s" and python does its classification it says in the terminal "bci_essentials.classification.mi_classifier : The shape of X is (11, 4, 512)" where the middle number is the number of channels in the optimal subset (in this case 4). You can tell what is the best subset by the terminal output when record_performance = True. You should see a table printed which shows the subsets and their accuracies. For example in the following table, OzP4PO8Pz, is the best subset, so there are 4 channels in the optimal subset.

   Step      Time  N Channels Channel Subset  Unique Combinations Tested in Step  Accuracy  Precision    Recall
1     1  0.256476           1             Oz                                   8  0.651685   0.651685  0.651685
2     2  0.512817           2           OzP4                                   7  0.715356   0.715356  0.715356
3     3  0.795229           3         OzP4Pz                                   6  0.704120   0.704120  0.704120
4     4  1.081679           4      OzP4PO8Pz                                   5  0.865169   0.865169  0.865169