### PR TITLE
Add multiple label properties to accommodate different headsets

### DIFF
--- a/bci_essentials/io/lsl_sources.py
+++ b/bci_essentials/io/lsl_sources.py
@@ -85,7 +85,18 @@ class LslEegSource(EegSource):
 
     @property
     def channel_labels(self) -> list[str]:
-        return self.get_channel_properties("name")
+        # Possible properties to use for labels, depends on headset used
+        label_properties = ["name", "label"]
+
+        for prop in label_properties:
+            labels = self.get_channel_properties(prop)
+
+            # Check that labels are not empty strings
+            if labels and not any(label == "" for label in labels):
+                output_labels = labels
+                break
+
+        return output_labels
 
     def get_samples(self) -> tuple[list[list], list]:
         return pull_from_lsl_inlet(self.__inlet)

--- a/bci_essentials/io/lsl_sources.py
+++ b/bci_essentials/io/lsl_sources.py
@@ -96,6 +96,11 @@ class LslEegSource(EegSource):
                 output_labels = labels
                 break
 
+        # If no valid labels found, create numbered channel names
+        if output_labels is None:
+            logger.warning("No valid channel labels found, using numbered channels")
+            output_labels = [f"Ch{i+1}" for i in range(self.n_channels)]
+
         return output_labels
 
     def get_samples(self) -> tuple[list[list], list]:

--- a/bci_essentials/io/lsl_sources.py
+++ b/bci_essentials/io/lsl_sources.py
@@ -87,6 +87,7 @@ class LslEegSource(EegSource):
     def channel_labels(self) -> list[str]:
         # Possible properties to use for labels, depends on headset used
         label_properties = ["name", "label"]
+        output_labels = None
 
         for prop in label_properties:
             labels = self.get_channel_properties(prop)


### PR DESCRIPTION
# Description
When using the DSI2LSL GUI the montage would not be detected by any of the paradigms backends. This was because the `LslEegSource.channel_labels` would only check for the `name` property, DSI2LSL writes the property as `label` instead of `name`. 

# Solution
I added a list of `label_properties` in the `channel_labels` method to check the appropriate one depending on the headset used.

# Testing
- You'll need an `xdf` file from a DSI stream to set up with `eeg_lsl_sim.py`, or a DSI headset to run the DSI2LSL gui.
- Run any of the `unity_backend.py` scripts and notice the channel names being populated in the terminal
- Modify `label_properties` to remove the `label` option in `lsl_sourcer.channel_labels`. Rerun the DSi stream and the `unity_backend.py` script, not the warning that the channels were not found and the placeholder `Chx` channel names
