### PR TITLE
Return single objects

### DIFF
--- a/bci_essentials/__init__.py
+++ b/bci_essentials/__init__.py
@@ -1,3 +1,10 @@
+# Import submodules to make them discoverable
+from . import classification
+from . import data_tank
+from . import io
+from . import paradigm
+from . import utils
+
 # Instantiate a parent logger for the library at default
 from .utils.logger import Logger
 

--- a/bci_essentials/__init__.py
+++ b/bci_essentials/__init__.py
@@ -1,4 +1,4 @@
-# Instantiate a parent logger for the library at the default level of logging.INFO
+# Instantiate a parent logger for the library at default
 from .utils.logger import Logger
 
 logger = Logger()

--- a/bci_essentials/__init__.py
+++ b/bci_essentials/__init__.py
@@ -6,8 +6,6 @@ from . import paradigm
 from . import utils
 
 # Instantiate a parent logger for the library at default
-=======
 from .utils.logger import Logger
 
 logger = Logger()
-

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -225,9 +225,11 @@ class BciController:
 
         """
 
-        eeg_start_time, eeg_end_time = self.__paradigm.get_eeg_start_and_end_times(
+        eeg_times = self.__paradigm.get_eeg_start_and_end_times(
             self.event_marker_buffer, self.event_timestamp_buffer
         )
+        eeg_start_time = eeg_times.start_time
+        eeg_end_time = eeg_times.end_time
 
         # No we actually need to wait until we have all the data for these markers
         eeg, timestamps = self.__data_tank.get_raw_eeg()

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -228,7 +228,7 @@ class BciController:
         eeg_times = self.__paradigm.get_eeg_start_and_end_times(
             self.event_marker_buffer, self.event_timestamp_buffer
         )
-        eeg_start_time = eeg_times.start_time
+        # eeg_start_time = eeg_times.start_time # Not used
         eeg_end_time = eeg_times.end_time
 
         # No we actually need to wait until we have all the data for these markers

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -238,13 +238,15 @@ class BciController:
         if timestamps[-1] < eeg_end_time:
             return False
 
-        X, y = self.__paradigm.process_markers(
+        processed_markers = self.__paradigm.process_markers(
             self.event_marker_buffer,
             self.event_timestamp_buffer,
             eeg,
             timestamps,
             self.fsample,
         )
+        X = processed_markers.processed_data
+        y = processed_markers.labels
 
         # Add the epochs to the data tank
         self.__data_tank.add_epochs(X, y)

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -225,11 +225,9 @@ class BciController:
 
         """
 
-        eeg_times = self.__paradigm.get_eeg_start_and_end_times(
+        eeg_start_time, eeg_end_time = self.__paradigm.get_eeg_start_and_end_times(
             self.event_marker_buffer, self.event_timestamp_buffer
         )
-        # eeg_start_time = eeg_times.start_time # Not used
-        eeg_end_time = eeg_times.end_time
 
         # No we actually need to wait until we have all the data for these markers
         eeg, timestamps = self.__data_tank.get_raw_eeg()
@@ -238,15 +236,13 @@ class BciController:
         if timestamps[-1] < eeg_end_time:
             return False
 
-        processed_markers = self.__paradigm.process_markers(
+        X, y = self.__paradigm.process_markers(
             self.event_marker_buffer,
             self.event_timestamp_buffer,
             eeg,
             timestamps,
             self.fsample,
         )
-        X = processed_markers.processed_data
-        y = processed_markers.labels
 
         # Add the epochs to the data tank
         self.__data_tank.add_epochs(X, y)

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -418,7 +418,7 @@ def __sfs(
         initial_accuracy = initial_results.accuracy
         initial_precision = initial_results.precision
         initial_recall = initial_results.recall
-        
+
         if metric == "accuracy":
             initial_performance = initial_accuracy
         elif metric == "precision":
@@ -650,7 +650,6 @@ def __sbs(
             preds : numpy.ndarray
                 The predictions from the model.
                 1D array with the same shape as `y`.
-        
                 shape = (`n_trials`)
             accuracy : float
                 The accuracy of the trained classification model.
@@ -934,7 +933,6 @@ def __sbfs(
             preds : numpy.ndarray
                 The predictions from the model.
                 1D array with the same shape as `y`.
-        
                 shape = (`n_trials`)
             accuracy : float
                 The accuracy of the trained classification model.
@@ -1394,7 +1392,6 @@ def __sffs(
             preds : numpy.ndarray
                 The predictions from the model.
                 1D array with the same shape as `y`.
-        
                 shape = (`n_trials`)
             accuracy : float
                 The accuracy of the trained classification model.

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -128,22 +128,24 @@ def channel_selection_by_method(
 
     Returns
     -------
-    new_channel_subset : list of `str`
-        The new best channel subset from the list of `channel_labels`.
-    self.clf : classifier
-        The trained classification model.
-    preds : numpy.ndarray
-        The predictions from the model.
-        1D array with the same shape as `y`.
-        shape = (`n_trials`)
-    accuracy : float
-        The accuracy of the trained classification model.
-    precision : float
-        The precision of the trained classification model.
-    recall : float
-        The recall of the trained classification model.
-    results_df : pandas.DataFrame
-        The dataframe containing the results of each step of channel selection.
+    channelSelectionOutput : ChannelSelectionOutput
+        ChannelSelectionOutput object containing the following attributes:
+            best_channel_subset : list of `str`
+                The new best channel subset from the list of `channel_labels`.
+            self.clf : classifier
+                The trained classification model.
+            preds : numpy.ndarray
+                The predictions from the model.
+                1D array with the same shape as `y`.
+                shape = (`n_trials`)
+            accuracy : float
+                The accuracy of the trained classification model.
+            precision : float
+                The precision of the trained classification model.
+            recall : float
+                The recall of the trained classification model.
+            results_df : pandas.DataFrame
+                The dataframe containing the results of each step of channel selection.
 
     """
 
@@ -361,23 +363,25 @@ def __sfs(
 
     Returns
     -------
-    new_channel_subset : list of `str`
-        The new best channel subset from the list of `channel_labels`.
-    self.clf : classifier
-        The trained classification model.
-    preds : numpy.ndarray
-        The predictions from the model.
-        1D array with the same shape as `y`.
+    channelSelectionOutput : ChannelSelectionOutput
+        ChannelSelectionOutput object containing the following attributes:
+            best_channel_subset : list of `str`
+                The new best channel subset from the list of `channel_labels`.
+            self.clf : classifier
+                The trained classification model.
+            preds : numpy.ndarray
+                The predictions from the model.
+                1D array with the same shape as `y`.
 
-        shape = (`n_trials`)
-    accuracy : float
-        The accuracy of the trained classification model.
-    precision : float
-        The precision of the trained classification model.
-    recall : float
-        The recall of the trained classification model.
-    results_df : pandas.DataFrame
-        The dataframe containing the results of each step of channel selection.
+                shape = (`n_trials`)
+            accuracy : float
+                The accuracy of the trained classification model.
+            precision : float
+                The precision of the trained classification model.
+            recall : float
+                The recall of the trained classification model.
+            results_df : pandas.DataFrame
+                The dataframe containing the results of each step of channel selection.
     """
     results_df = pd.DataFrame(
         columns=[
@@ -637,23 +641,25 @@ def __sbs(
 
     Returns
     -------
-    new_channel_subset : list of `str`
-        The new best channel subset from the list of `channel_labels`.
-    self.clf : classifier
-        The trained classification model.
-    preds : numpy.ndarray
-        The predictions from the model.
-        1D array with the same shape as `y`.
-
-        shape = (`n_trials`)
-    accuracy : float
-        The accuracy of the trained classification model.
-    precision : float
-        The precision of the trained classification model.
-    recall : float
-        The recall of the trained classification model.
-    results_df : pandas.DataFrame
-        A dataframe containing the performance metrics at each step.
+    channelSelectionOutput : ChannelSelectionOutput
+        ChannelSelectionOutput object containing the following attributes:
+            best_channel_subset : list of `str`
+                The new best channel subset from the list of `channel_labels`.
+            self.clf : classifier
+                The trained classification model.
+            preds : numpy.ndarray
+                The predictions from the model.
+                1D array with the same shape as `y`.
+        
+                shape = (`n_trials`)
+            accuracy : float
+                The accuracy of the trained classification model.
+            precision : float
+                The precision of the trained classification model.
+            recall : float
+                The recall of the trained classification model.
+            results_df : pandas.DataFrame
+                The dataframe containing the results of each step of channel selection.
 
 
     """
@@ -919,23 +925,25 @@ def __sbfs(
 
     Returns
     -------
-    new_channel_subset : list of `str`
-        The new best channel subset from the list of `channel_labels`.
-    self.clf : classifier
-        The trained classification model.
-    preds : numpy.ndarray
-        The predictions from the model.
-        1D array with the same shape as `y`.
-
-        shape = (`n_trials`)
-    accuracy : float
-        The accuracy of the trained classification model.
-    precision : float
-        The precision of the trained classification model.
-    recall : float
-        The recall of the trained classification model.
-    results_df : pandas.DataFrame
-        A dataframe containing the performance metrics at each step.
+    channelSelectionOutput : ChannelSelectionOutput
+        ChannelSelectionOutput object containing the following attributes:
+            best_channel_subset : list of `str`
+                The new best channel subset from the list of `channel_labels`.
+            self.clf : classifier
+                The trained classification model.
+            preds : numpy.ndarray
+                The predictions from the model.
+                1D array with the same shape as `y`.
+        
+                shape = (`n_trials`)
+            accuracy : float
+                The accuracy of the trained classification model.
+            precision : float
+                The precision of the trained classification model.
+            recall : float
+                The recall of the trained classification model.
+            results_df : pandas.DataFrame
+                The dataframe containing the results of each step of channel selection.
 
 
     """
@@ -1377,23 +1385,25 @@ def __sffs(
 
     Returns
     -------
-    new_channel_subset : list of `str`
-        The new best channel subset from the list of `channel_labels`.
-    self.clf : classifier
-        The trained classification model.
-    preds : numpy.ndarray
-        The predictions from the model.
-        1D array with the same shape as `y`.
-
-        shape = (`n_trials`)
-    accuracy : float
-        The accuracy of the trained classification model.
-    precision : float
-        The precision of the trained classification model.
-    recall : float
-        The recall of the trained classification model.
-    results_df : pandas.DataFrame
-        A dataframe containing the performance metrics at each step.
+    channelSelectionOutput : ChannelSelectionOutput
+        ChannelSelectionOutput object containing the following attributes:
+            best_channel_subset : list of `str`
+                The new best channel subset from the list of `channel_labels`.
+            self.clf : classifier
+                The trained classification model.
+            preds : numpy.ndarray
+                The predictions from the model.
+                1D array with the same shape as `y`.
+        
+                shape = (`n_trials`)
+            accuracy : float
+                The accuracy of the trained classification model.
+            precision : float
+                The precision of the trained classification model.
+            recall : float
+                The recall of the trained classification model.
+            results_df : pandas.DataFrame
+                The dataframe containing the results of each step of channel selection.
 
 
     """

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -412,13 +412,13 @@ def __sfs(
 
     # Get the performance of the initial subset, if possible
     try:
-        (
-            initial_model,
-            initial_preds,
-            initial_accuracy,
-            initial_precision,
-            initial_recall,
-        ) = kernel_func(X[:, sfs_subset, :], y)
+        initial_results = kernel_func(X[:, sfs_subset, :], y)
+        initial_model = initial_results.model
+        initial_preds = initial_results.preds
+        initial_accuracy = initial_results.accuracy
+        initial_precision = initial_results.precision
+        initial_recall = initial_results.recall
+        
         if metric == "accuracy":
             initial_performance = initial_accuracy
         elif metric == "precision":
@@ -481,11 +481,11 @@ def __sfs(
 
         # Extract the outputs
         for output in outputs:
-            models.append(output[0])
-            predictions.append(output[1])
-            accuracies.append(output[2])
-            precisions.append(output[3])
-            recalls.append(output[4])
+            models.append(output.model)
+            predictions.append(output.preds)
+            accuracies.append(output.accuracy)
+            precisions.append(output.precision)
+            recalls.append(output.recall)
 
         # Get the performance metric
         if metric == "accuracy":
@@ -692,13 +692,13 @@ def __sbs(
             sbs_subset.append(i)
 
     # Get the performance of the initial subset
-    (
-        initial_model,
-        initial_preds,
-        initial_accuracy,
-        initial_precision,
-        initial_recall,
-    ) = kernel_func(X[:, sbs_subset, :], y)
+    initial_results = kernel_func(X[:, sbs_subset, :], y)
+    initial_model = initial_results.model
+    initial_preds = initial_results.preds
+    initial_accuracy = initial_results.accuracy
+    initial_precision = initial_results.precision
+    initial_recall = initial_results.recall
+
     if metric == "accuracy":
         initial_performance = initial_accuracy
     elif metric == "precision":
@@ -764,11 +764,11 @@ def __sbs(
 
         # Extract the outputs
         for output in outputs:
-            models.append(output[0])
-            predictions.append(output[1])
-            accuracies.append(output[2])
-            precisions.append(output[3])
-            recalls.append(output[4])
+            models.append(output.model)
+            predictions.append(output.preds)
+            accuracies.append(output.accuracy)
+            precisions.append(output.precision)
+            recalls.append(output.recall)
 
         # Get the performance metric
         if metric == "accuracy":
@@ -983,13 +983,13 @@ def __sbfs(
 
     # Get the performance of the initial subset, if possible
     try:
-        (
-            initial_model,
-            initial_preds,
-            initial_accuracy,
-            initial_precision,
-            initial_recall,
-        ) = kernel_func(X[:, sbfs_subset, :], y)
+        initial_results = kernel_func(X[:, sbfs_subset, :], y)
+        initial_model = initial_results.model
+        initial_preds = initial_results.preds
+        initial_accuracy = initial_results.accuracy
+        initial_precision = initial_results.precision
+        initial_recall = initial_results.recall
+
         if metric == "accuracy":
             initial_performance = initial_accuracy
         elif metric == "precision":
@@ -1064,11 +1064,11 @@ def __sbfs(
 
         # Extract the outputs
         for output in outputs:
-            models.append(output[0])
-            predictions.append(output[1])
-            accuracies.append(output[2])
-            precisions.append(output[3])
-            recalls.append(output[4])
+            models.append(output.model)
+            predictions.append(output.preds)
+            accuracies.append(output.accuracy)
+            precisions.append(output.precision)
+            recalls.append(output.recall)
 
         # Get the performance metric
         if metric == "accuracy":
@@ -1197,11 +1197,11 @@ def __sbfs(
 
             # Extract the outputs
             for output in outputs:
-                models.append(output[0])
-                predictions.append(output[1])
-                accuracies.append(output[2])
-                precisions.append(output[3])
-                recalls.append(output[4])
+                models.append(output.model)
+                predictions.append(output.preds)
+                accuracies.append(output.accuracy)
+                precisions.append(output.precision)
+                recalls.append(output.recall)
 
             # Get the performance metric
             if metric == "accuracy":
@@ -1441,13 +1441,13 @@ def __sffs(
 
     # Get the performance of the initial subset, if possible
     try:
-        (
-            initial_model,
-            initial_preds,
-            initial_accuracy,
-            initial_precision,
-            initial_recall,
-        ) = kernel_func(X[:, sffs_subset, :], y)
+        initial_results = kernel_func(X[:, sffs_subset, :], y)
+        initial_model = initial_results.model
+        initial_preds = initial_results.preds
+        initial_accuracy = initial_results.accuracy
+        initial_precision = initial_results.precision
+        initial_recall = initial_results.recall
+
         if metric == "accuracy":
             initial_performance = initial_accuracy
         elif metric == "precision":
@@ -1517,11 +1517,11 @@ def __sffs(
 
         # Extract the outputs
         for output in outputs:
-            models.append(output[0])
-            predictions.append(output[1])
-            accuracies.append(output[2])
-            precisions.append(output[3])
-            recalls.append(output[4])
+            models.append(output.model)
+            predictions.append(output.preds)
+            accuracies.append(output.accuracy)
+            precisions.append(output.precision)
+            recalls.append(output.recall)
 
         # Get the performance metric
         if metric == "accuracy":
@@ -1651,11 +1651,11 @@ def __sffs(
 
             # Extract the outputs
             for output in outputs:
-                models.append(output[0])
-                predictions.append(output[1])
-                accuracies.append(output[2])
-                precisions.append(output[3])
-                recalls.append(output[4])
+                models.append(output.model)
+                predictions.append(output.preds)
+                accuracies.append(output.accuracy)
+                precisions.append(output.precision)
+                recalls.append(output.recall)
 
             # Get the performance metric
             if metric == "accuracy":

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -14,11 +14,49 @@ from joblib import Parallel, delayed
 import time
 import numpy as np
 import pandas as pd
+from dataclasses import dataclass, field
 from .utils.logger import Logger  # Logger wrapper
+from sklearn.pipeline import Pipeline
 
 # Instantiate a logger for the module at the default level of logging.INFO
 # Logs to bci_essentials.__module__) where __module__ is the name of the module
 logger = Logger(name=__name__)
+
+
+@dataclass
+class ChannelSelectionOutput:
+    """
+    Dataclass to store output from channel selection.
+
+    best_channel_subset : list of `str`
+        The best channel subset from the list of 'channel_labels'.
+
+    best_model : classifier
+        The trained classification model.
+
+    best_preds : numpy.ndarray
+        The predictions from the model.
+
+    best_accuracy : float
+        The accuracy of the trained classification model.
+
+    best_precision : float
+        The precision of the trained classification model.
+
+    best_recall : float
+        The recall of the trained classification model.
+
+    results_df : pandas.DataFrame
+        A dataframe containing the performance metrics at each step.
+    """
+
+    best_channel_subset: list = field(default_factory=list)
+    best_model: Pipeline = field(default=None)
+    best_preds: np.ndarray = field(default_factory=np.ndarray)
+    best_accuracy: float = field(default=0.0)
+    best_precision: float = field(default=0.0)
+    best_recall: float = field(default=0.0)
+    results_df: pd.DataFrame = field(default_factory=pd.DataFrame)
 
 
 def channel_selection_by_method(
@@ -525,7 +563,7 @@ def __sfs(
 
     # Get the best model
 
-    return (
+    return ChannelSelectionOutput(
         best_channel_subset,
         best_model,
         best_preds,
@@ -804,7 +842,7 @@ def __sbs(
     logger.debug("%s : %s", metric, best_performance)
     logger.debug("Time to optimal subset: %s s", time.time() - start_time)
 
-    return (
+    return ChannelSelectionOutput(
         best_channel_subset,
         best_model,
         best_preds,
@@ -1258,7 +1296,7 @@ def __sbfs(
     logger.debug("%s : %s", metric, best_performance)
     logger.debug("Time to optimal subset: %s s", time.time() - start_time)
 
-    return (
+    return ChannelSelectionOutput(
         best_channel_subset,
         best_model,
         best_preds,
@@ -1707,7 +1745,7 @@ def __sffs(
     logger.debug("%s : %s", metric, best_performance)
     logger.debug("Time to optimal subset: %s s", time.time() - start_time)
 
-    return (
+    return ChannelSelectionOutput(
         best_channel_subset,
         best_model,
         best_preds,

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -1762,7 +1762,7 @@ def __sffs(
 
     if record_performance is True:
         logger.info(results_df)
-        
+
     return ChannelSelectionOutput(
         best_channel_subset,
         best_model,

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -22,7 +22,11 @@ from pyriemann.estimation import XdawnCovariances
 from pyriemann.tangentspace import TangentSpace
 
 # Import bci_essentials modules and methods
-from ..classification.generic_classifier import GenericClassifier, Prediction, KernelResults
+from ..classification.generic_classifier import (
+    GenericClassifier,
+    Prediction,
+    KernelResults,
+)
 from ..signal_processing import lico
 from ..channel_selection import channel_selection_by_method
 from ..utils.logger import Logger  # Logger wrapper
@@ -314,7 +318,7 @@ class ErpRgClassifier(GenericClassifier):
             recall = recall_score(self.y, preds)
 
             return KernelResults(model, preds, accuracy, precision, recall)
-        
+
         def __extract_kernel_results(X, y):
             """Wrapper function to call __erp_rg_kernel and extract KernelResults.
 
@@ -332,22 +336,20 @@ class ErpRgClassifier(GenericClassifier):
                 (model, preds, accuracy, precision, recall)
             """
             results = __erp_rg_kernel(X, y)
-            return results.model, results.preds, results.accuracy, results.precision, results.recall
+            return (
+                results.model,
+                results.preds,
+                results.accuracy,
+                results.precision,
+                results.recall,
+            )
 
         # Check if channel selection is true
         if self.channel_selection_setup:
             logger.info("Doing channel selection")
             logger.debug("Initial subset: %s", self.chs_initial_subset)
 
-            (
-                updated_subset,
-                updated_model,
-                preds,
-                accuracy,
-                precision,
-                recall,
-                results_df,
-            ) = channel_selection_by_method(
+            channel_selection_results = channel_selection_by_method(
                 __extract_kernel_results,
                 self.X,
                 self.y,
@@ -362,16 +364,22 @@ class ErpRgClassifier(GenericClassifier):
                 self.chs_n_jobs,
             )  # njobs, output messages
 
-            logger.info("The optimal subset is %s", updated_subset)
+            preds = channel_selection_results.best_preds
+            accuracy = channel_selection_results.best_accuracy
+            precision = channel_selection_results.best_precision
+            recall = channel_selection_results.best_recall
 
-            self.results_df = results_df
-            self.subset = updated_subset
-            self.clf = updated_model
+            logger.info(
+                "The optimal subset is %s",
+                channel_selection_results.best_channel_subset,
+            )
+
+            self.results_df = channel_selection_results.results_df
+            self.subset = channel_selection_results.best_channel_subset
+            self.clf = channel_selection_results.best_model
         else:
             logger.warning("Not doing channel selection")
-            current_results = __erp_rg_kernel(
-                self.X, self.y
-            )
+            current_results = __erp_rg_kernel(self.X, self.y)
             self.clf = current_results.model
             preds = current_results.preds
             accuracy = current_results.accuracy

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -381,7 +381,7 @@ class ErpRgClassifier(GenericClassifier):
         else:
             logger.warning("Not doing channel selection")
             X = self.get_subset(self.X, self.subset, self.channel_labels)
-            
+
             current_results = __erp_rg_kernel(self.X, self.y)
             self.clf = current_results.model
             preds = current_results.preds

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -290,38 +290,13 @@ class ErpRgClassifier(GenericClassifier):
 
             return KernelResults(model, preds, accuracy, precision, recall)
 
-        def __extract_kernel_results(X, y):
-            """Wrapper function to extract KernelResults to use in channel_selection_by_method.
-
-            Parameters
-            ----------
-            X : numpy.ndarray
-                Input data for training.
-            y : numpy.ndarray
-                Target labels for training.
-
-            Returns
-            -------
-            tuple
-                Extracted values from KernelResults formatted as:
-                (model, preds, accuracy, precision, recall)
-            """
-            results = __erp_rg_kernel(X, y)
-            return (
-                results.model,
-                results.preds,
-                results.accuracy,
-                results.precision,
-                results.recall,
-            )
-
         # Check if channel selection is true
         if self.channel_selection_setup:
             logger.info("Doing channel selection")
             logger.debug("Initial subset: %s", self.chs_initial_subset)
 
             channel_selection_results = channel_selection_by_method(
-                __extract_kernel_results,
+                __erp_rg_kernel,
                 self.X,
                 self.y,
                 self.channel_labels,  # kernel setup

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -320,7 +320,7 @@ class ErpRgClassifier(GenericClassifier):
             return KernelResults(model, preds, accuracy, precision, recall)
 
         def __extract_kernel_results(X, y):
-            """Wrapper function to call __erp_rg_kernel and extract KernelResults.
+            """Wrapper function to extract KernelResults to use in channel_selection_by_method.
 
             Parameters
             ----------

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -194,17 +194,19 @@ class ErpRgClassifier(GenericClassifier):
 
             Returns
             -------
-            model : classifier
-                The trained classification model.
-            preds : numpy.ndarray
-                The predictions from the model.
-                1D array with the same shape as `y`.
-            accuracy : float
-                The accuracy of the trained classification model.
-            precision : float
-                The precision of the trained classification model.
-            recall : float
-                The recall of the trained classification model.
+            kernelResults : KernelResults
+                KernelResults object containing the following attributes:
+                    model : classifier
+                        The trained classification model.
+                    preds : numpy.ndarray
+                        The predictions from the model.
+                        1D array with the same shape as `y`.
+                    accuracy : float
+                        The accuracy of the trained classification model.
+                    precision : float
+                        The precision of the trained classification model.
+                    recall : float
+                        The recall of the trained classification model.
 
             """
             for train_idx, test_idx in cv.split(X, y):

--- a/bci_essentials/classification/erp_rg_classifier.py
+++ b/bci_essentials/classification/erp_rg_classifier.py
@@ -382,7 +382,7 @@ class ErpRgClassifier(GenericClassifier):
             logger.warning("Not doing channel selection")
             X = self.get_subset(self.X, self.subset, self.channel_labels)
 
-            current_results = __erp_rg_kernel(self.X, self.y)
+            current_results = __erp_rg_kernel(X, self.y)
             self.clf = current_results.model
             preds = current_results.preds
             accuracy = current_results.accuracy

--- a/bci_essentials/classification/erp_single_channel_classifier.py
+++ b/bci_essentials/classification/erp_single_channel_classifier.py
@@ -273,38 +273,13 @@ class ErpSingleChannelClassifier(GenericClassifier):
 
             return KernelResults(model, preds, accuracy, precision, recall)
 
-        def __extract_kernel_results(X, y):
-            """Wrapper function to extract KernelResults to use in channel_selection_by_method.
-
-            Parameters
-            ----------
-            X : numpy.ndarray
-                Input data for training.
-            y : numpy.ndarray
-                Target labels for training.
-
-            Returns
-            -------
-            tuple
-                Extracted values from KernelResults formatted as:
-                (model, preds, accuracy, precision, recall)
-            """
-            results = __erp_single_channel_kernel(X, y)
-            return (
-                results.model,
-                results.preds,
-                results.accuracy,
-                results.precision,
-                results.recall,
-            )
-
         # Check if channel selection is true
         if self.channel_selection_setup:
             logger.info("Doing channel selection")
             logger.debug("Initial subset: %s", self.chs_initial_subset)
 
             channel_selection_results = channel_selection_by_method(
-                __extract_kernel_results,
+                __erp_single_channel_kernel,
                 self.X,
                 self.y,
                 self.channel_labels,  # kernel setup

--- a/bci_essentials/classification/erp_single_channel_classifier.py
+++ b/bci_essentials/classification/erp_single_channel_classifier.py
@@ -274,7 +274,7 @@ class ErpSingleChannelClassifier(GenericClassifier):
             return KernelResults(model, preds, accuracy, precision, recall)
 
         def __extract_kernel_results(X, y):
-            """Wrapper function to call __erp_single_channel_kernel and extract KernelResults.
+            """Wrapper function to extract KernelResults to use in channel_selection_by_method.
 
             Parameters
             ----------

--- a/bci_essentials/classification/erp_single_channel_classifier.py
+++ b/bci_essentials/classification/erp_single_channel_classifier.py
@@ -150,17 +150,19 @@ class ErpSingleChannelClassifier(GenericClassifier):
 
             Returns
             -------
-            model : classifier
-                The trained classification model.
-            preds : numpy.ndarray
-                The predictions from the model.
-                1D array with the same shape as `y`.
-            accuracy : float
-                The accuracy of the trained classification model.
-            precision : float
-                The precision of the trained classification model.
-            recall : float
-                The recall of the trained classification model.
+            kernelResults : KernelResults
+                KernelResults object containing the following attributes:
+                    model : classifier
+                        The trained classification model.
+                    preds : numpy.ndarray
+                        The predictions from the model.
+                        1D array with the same shape as `y`.
+                    accuracy : float
+                        The accuracy of the trained classification model.
+                    precision : float
+                        The precision of the trained classification model.
+                    recall : float
+                        The recall of the trained classification model.
 
             """
             print("X shape: ", X.shape)

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -56,11 +56,11 @@ class KernelResults:
         The recall of the trained classification model.
     """
 
-    model: Pipeline
-    preds: np.ndarray
-    accuracy: float
-    precision: float
-    recall: float
+    model: Pipeline = field(default=None)
+    preds: np.ndarray = field(default_factory=np.ndarray)
+    accuracy: float = field(default=0.0)
+    precision: float = field(default=0.0)
+    recall: float = field(default=0.0)
 
 class GenericClassifier(ABC):
     """The base generic classifier class for other classifiers."""

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
 import numpy as np
+from sklearn.pipeline import Pipeline
 
 from ..utils.logger import Logger  # Logger wrapper
 
@@ -35,6 +36,31 @@ class Prediction:
     labels: list = field(default_factory=list)
     probabilities: list = field(default_factory=list)
 
+@dataclass
+class KernelResults:
+    """Dataclass to store output from the kernel methods
+
+    model: classifier
+        The trained classification model.
+
+    preds : numpy.ndarray
+        The predictions from the model.
+
+    accuracy : float
+        The accuracy of the trained classification model.
+
+    precision : float
+        The precision of the trained classification model.
+
+    recall : float
+        The recall of the trained classification model.
+    """
+
+    model: Pipeline
+    preds: np.ndarray
+    accuracy: float
+    precision: float
+    recall: float
 
 class GenericClassifier(ABC):
     """The base generic classifier class for other classifiers."""

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -40,7 +40,7 @@ class Prediction:
 class KernelResults:
     """Dataclass to store output from the kernel methods
 
-    model: classifier
+    model : classifier
         The trained classification model.
 
     preds : numpy.ndarray

--- a/bci_essentials/classification/generic_classifier.py
+++ b/bci_essentials/classification/generic_classifier.py
@@ -36,6 +36,7 @@ class Prediction:
     labels: list = field(default_factory=list)
     probabilities: list = field(default_factory=list)
 
+
 @dataclass
 class KernelResults:
     """Dataclass to store output from the kernel methods
@@ -61,6 +62,7 @@ class KernelResults:
     accuracy: float = field(default=0.0)
     precision: float = field(default=0.0)
     recall: float = field(default=0.0)
+
 
 class GenericClassifier(ABC):
     """The base generic classifier class for other classifiers."""

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -232,7 +232,7 @@ class MiClassifier(GenericClassifier):
             return KernelResults(model, preds, accuracy, precision, recall)
 
         def __extract_kernel_results(X, y):
-            """Wrapper function to call __mi_kernel and extract KernelResults.
+            """Wrapper function to extract KernelResults to use in channel_selection_by_method.
 
             Parameters
             ----------

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -222,31 +222,6 @@ class MiClassifier(GenericClassifier):
 
             return KernelResults(model, preds, accuracy, precision, recall)
 
-        def __extract_kernel_results(X, y):
-            """Wrapper function to extract KernelResults to use in channel_selection_by_method.
-
-            Parameters
-            ----------
-            X : numpy.ndarray
-                Input data for training.
-            y : numpy.ndarray
-                Target labels for training.
-
-            Returns
-            -------
-            tuple
-                Extracted values from KernelResults formatted as:
-                (model, preds, accuracy, precision, recall)
-            """
-            results = __mi_kernel(X, y)
-            return (
-                results.model,
-                results.preds,
-                results.accuracy,
-                results.precision,
-                results.recall,
-            )
-
         # Check if channel selection is true
         if self.channel_selection_setup:
             if self.chs_iterative_selection is True and self.subset is not None:
@@ -260,7 +235,7 @@ class MiClassifier(GenericClassifier):
 
             logger.info("Doing channel selection")
             channel_selection_results = channel_selection_by_method(
-                __extract_kernel_results,
+                __mi_kernel,
                 self.X,
                 self.y,
                 self.channel_labels,  # kernel setup

--- a/bci_essentials/classification/mi_classifier.py
+++ b/bci_essentials/classification/mi_classifier.py
@@ -184,17 +184,20 @@ class MiClassifier(GenericClassifier):
 
             Returns
             -------
-            model : classifier
-                The trained classification model.
-            preds : numpy.ndarray
-                The predictions from the model.
-                1D array with the same shape as `suby`.
-            accuracy : float
-                The accuracy of the trained classification model.
-            precision : float
-                The precision of the trained classification model.
-            recall : float
-                The recall of the trained classification model.
+            kernelResults : KernelResults
+                KernelResults object containing the following attributes:
+                    model : classifier
+                        The trained classification model.
+                    preds : numpy.ndarray
+                        The predictions from the model.
+                        1D array with the same shape as `suby`.
+                    accuracy : float
+                        The accuracy of the trained classification model.
+                    precision : float
+                        The precision of the trained classification model.
+                    recall : float
+                        The recall of the trained classification model.
+
 
             """
             for train_idx, test_idx in self.cv.split(subX, suby):

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -269,7 +269,7 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
             return KernelResults(model, preds, accuracy, precision, recall)
 
         def __extract_kernel_results(X, y):
-            """Wrapper function to call __ssvep_kernel and extract KernelResults.
+            """Wrapper function to extract KernelResults to use in channel_selection_by_method.
 
             Parameters
             ----------

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -212,17 +212,20 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
 
             Returns
             -------
-            model : classifier
-                The trained classification model.
-            preds : numpy.ndarray
-                The predictions from the model.
-                1D array with the same shape as `suby`.
-            accuracy : float
-                The accuracy of the trained classification model.
-            precision : float
-                The precision of the trained classification model.
-            recall : float
-                The recall of the trained classification model.
+            kernelResults : KernelResults
+                KernelResults object containing the following attributes:
+                    model : classifier
+                        The trained classification model.
+                    preds : numpy.ndarray
+                        The predictions from the model.
+                        1D array with the same shape as `suby`.
+                    accuracy : float
+                        The accuracy of the trained classification model.
+                    precision : float
+                        The precision of the trained classification model.
+                    recall : float
+                        The recall of the trained classification model.
+
 
             """
             for train_idx, test_idx in self.cv.split(subX, suby):

--- a/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
+++ b/bci_essentials/classification/ssvep_riemannian_mdm_classifier.py
@@ -278,37 +278,12 @@ class SsvepRiemannianMdmClassifier(GenericClassifier):
 
             return KernelResults(model, preds, accuracy, precision, recall)
 
-        def __extract_kernel_results(X, y):
-            """Wrapper function to extract KernelResults to use in channel_selection_by_method.
-
-            Parameters
-            ----------
-            X : numpy.ndarray
-                Input data for training.
-            y : numpy.ndarray
-                Target labels for training.
-
-            Returns
-            -------
-            tuple
-                Extracted values from KernelResults formatted as:
-                (model, preds, accuracy, precision, recall)
-            """
-            results = __ssvep_kernel(X, y)
-            return (
-                results.model,
-                results.preds,
-                results.accuracy,
-                results.precision,
-                results.recall,
-            )
-
         # Check if channel selection is true
         if self.channel_selection_setup:
             logger.info("Doing channel selection")
 
             channel_selection_results = channel_selection_by_method(
-                __extract_kernel_results,
+                __ssvep_kernel,
                 self.X,
                 self.y,
                 self.channel_labels,  # kernel setup

--- a/bci_essentials/paradigm/mi_paradigm.py
+++ b/bci_essentials/paradigm/mi_paradigm.py
@@ -59,10 +59,12 @@ class MiParadigm(Paradigm):
 
         Returns
         -------
-        float
-            Start time.
-        float
-            End time.
+        startAndEndTimes : StartAndEndTimes
+            StartAndEndTimes object containing the following:
+                float
+                    Start time.
+                float
+                    End time.
         """
         start_time = timestamps[0] - self.buffer_time
 
@@ -89,10 +91,12 @@ class MiParadigm(Paradigm):
 
         Returns
         -------
-        np.array
-            Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
-        np.array
-            Labels. Shape is (n_epochs).
+        processedMarkers : ProcessedMarkers
+            ProcessedMarkers object containing the following:
+                np.array
+                    Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
+                np.array
+                    Labels. Shape is (n_epochs).
         """
 
         # Initialize y

--- a/bci_essentials/paradigm/mi_paradigm.py
+++ b/bci_essentials/paradigm/mi_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm, StartAndEndTimes
+from .paradigm import Paradigm, StartAndEndTimes, ProcessedMarkers
 
 
 class MiParadigm(Paradigm):
@@ -133,7 +133,7 @@ class MiParadigm(Paradigm):
 
             y[i] = label
 
-        return X, y
+        return ProcessedMarkers(X, y)
 
     # TODO: Implement this to check compatibility between paradigm and classifier
     def check_compatibility(self):

--- a/bci_essentials/paradigm/mi_paradigm.py
+++ b/bci_essentials/paradigm/mi_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm
+from .paradigm import Paradigm, StartAndEndTimes
 
 
 class MiParadigm(Paradigm):
@@ -68,7 +68,7 @@ class MiParadigm(Paradigm):
 
         end_time = timestamps[-1] + float(markers[-1].split(",")[-1]) + self.buffer_time
 
-        return start_time, end_time
+        return StartAndEndTimes(start_time, end_time)
 
     def process_markers(self, markers, marker_timestamps, eeg, eeg_timestamps, fsample):
         """

--- a/bci_essentials/paradigm/mi_paradigm.py
+++ b/bci_essentials/paradigm/mi_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm, StartAndEndTimes, ProcessedMarkers
+from .paradigm import Paradigm
 
 
 class MiParadigm(Paradigm):
@@ -62,18 +62,16 @@ class MiParadigm(Paradigm):
 
         Returns
         -------
-        startAndEndTimes : StartAndEndTimes
-            StartAndEndTimes object containing the following:
-                float
-                    Start time.
-                float
-                    End time.
+        float
+            Start time.
+        float
+            End time.
         """
         start_time = timestamps[0] - self.buffer_time
 
         end_time = timestamps[-1] + float(markers[-1].split(",")[-1]) + self.buffer_time
 
-        return StartAndEndTimes(start_time, end_time)
+        return start_time, end_time
 
     def process_markers(self, markers, marker_timestamps, eeg, eeg_timestamps, fsample):
         """
@@ -94,12 +92,10 @@ class MiParadigm(Paradigm):
 
         Returns
         -------
-        processedMarkers : ProcessedMarkers
-            ProcessedMarkers object containing the following:
-                np.array
-                    Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
-                np.array
-                    Labels. Shape is (n_epochs).
+        np.array
+            Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
+        np.array
+            Labels. Shape is (n_epochs).
         """
 
         # Initialize y
@@ -140,7 +136,7 @@ class MiParadigm(Paradigm):
 
             y[i] = label
 
-        return ProcessedMarkers(X, y)
+        return X, y
 
     # TODO: Implement this to check compatibility between paradigm and classifier
     def check_compatibility(self):

--- a/bci_essentials/paradigm/p300_paradigm.py
+++ b/bci_essentials/paradigm/p300_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm, StartAndEndTimes
+from .paradigm import Paradigm, StartAndEndTimes, ProcessedMarkers
 
 
 class P300Paradigm(Paradigm):
@@ -173,7 +173,7 @@ class P300Paradigm(Paradigm):
         # # object_epochs_mean = np.mean(object_epochs, axis=1)
         # X = object_epochs_mean
 
-        return X, y
+        return ProcessedMarkers(X, y)
 
     # TODO: Implement this
     def check_compatibility(self):

--- a/bci_essentials/paradigm/p300_paradigm.py
+++ b/bci_essentials/paradigm/p300_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm
+from .paradigm import Paradigm, StartAndEndTimes
 
 
 class P300Paradigm(Paradigm):
@@ -76,7 +76,7 @@ class P300Paradigm(Paradigm):
 
         end_time = timestamps[-1] + self.epoch_end + self.buffer_time
 
-        return start_time, end_time
+        return StartAndEndTimes(start_time, end_time)
 
     def process_markers(self, markers, marker_timestamps, eeg, eeg_timestamps, fsample):
         """

--- a/bci_essentials/paradigm/p300_paradigm.py
+++ b/bci_essentials/paradigm/p300_paradigm.py
@@ -67,10 +67,12 @@ class P300Paradigm(Paradigm):
 
         Returns
         -------
-        float
-            Start time.
-        float
-            End time.
+        startAndEndTimes : StartAndEndTimes
+            StartAndEndTimes object containing the following:
+                float
+                    Start time.
+                float
+                    End time.
         """
         start_time = timestamps[0] + self.epoch_start - self.buffer_time
 
@@ -97,10 +99,12 @@ class P300Paradigm(Paradigm):
 
         Returns
         -------
-        np.array
-            Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
-        np.array
-            Labels. Shape is (n_epochs).
+        processedMarkers : ProcessedMarkers
+            ProcessedMarkers object containing the following:
+                np.array
+                    Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
+                np.array
+                    Labels. Shape is (n_epochs).
         """
 
         n_channels, _ = eeg.shape

--- a/bci_essentials/paradigm/p300_paradigm.py
+++ b/bci_essentials/paradigm/p300_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm, StartAndEndTimes, ProcessedMarkers
+from .paradigm import Paradigm
 
 
 class P300Paradigm(Paradigm):
@@ -67,18 +67,16 @@ class P300Paradigm(Paradigm):
 
         Returns
         -------
-        startAndEndTimes : StartAndEndTimes
-            StartAndEndTimes object containing the following:
-                float
-                    Start time.
-                float
-                    End time.
+        float
+            Start time.
+        float
+            End time.
         """
         start_time = timestamps[0] + self.epoch_start - self.buffer_time
 
         end_time = timestamps[-1] + self.epoch_end + self.buffer_time
 
-        return StartAndEndTimes(start_time, end_time)
+        return start_time, end_time
 
     def process_markers(self, markers, marker_timestamps, eeg, eeg_timestamps, fsample):
         """
@@ -99,12 +97,10 @@ class P300Paradigm(Paradigm):
 
         Returns
         -------
-        processedMarkers : ProcessedMarkers
-            ProcessedMarkers object containing the following:
-                np.array
-                    Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
-                np.array
-                    Labels. Shape is (n_epochs).
+        np.array
+            Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
+        np.array
+            Labels. Shape is (n_epochs).
         """
 
         n_channels, _ = eeg.shape
@@ -176,7 +172,7 @@ class P300Paradigm(Paradigm):
         # # object_epochs_mean = np.mean(object_epochs, axis=1)
         # X = object_epochs_mean
 
-        return ProcessedMarkers(X, y)
+        return X, y
 
     # TODO: Implement this
     def check_compatibility(self):

--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -24,6 +24,21 @@ class StartAndEndTimes:
     start_time: float = field(default_factory=0.0)
     end_time: float = field(default_factory=0.0)
 
+@dataclass
+class ProcessedMarkers:
+    """Dataclass for processed markers.
+
+    processed_data : np.ndarray
+        Processed EEG data.
+    
+    labels : np.ndarray
+        Labels.
+
+    """
+
+    processed_data: np.ndarray = field(default_factory=np.array)
+    labels: np.ndarray = field(default_factory=np.array)
+
 class Paradigm(ABC):
     def __init__(self, filters=[5, 30], channel_subset=None):
         """

--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -1,5 +1,6 @@
 import numpy as np
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 
 from ..utils.logger import Logger
 from ..signal_processing import bandpass
@@ -8,6 +9,20 @@ from ..signal_processing import bandpass
 # Logs to bci_essentials.__module__) where __module__ is the name of the module
 logger = Logger(name=__name__)
 
+@dataclass
+class StartAndEndTimes:
+    """Dataclass for start and end times of EEG data.
+
+    start_time : float
+        Start time.
+
+    end_time : float
+        End time.
+
+    """
+
+    start_time: float = field(default_factory=0.0)
+    end_time: float = field(default_factory=0.0)
 
 class Paradigm(ABC):
     def __init__(self, filters=[5, 30], channel_subset=None):

--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -9,6 +9,7 @@ from ..signal_processing import bandpass
 # Logs to bci_essentials.__module__) where __module__ is the name of the module
 logger = Logger(name=__name__)
 
+
 @dataclass
 class StartAndEndTimes:
     """Dataclass for start and end times of EEG data.
@@ -24,13 +25,14 @@ class StartAndEndTimes:
     start_time: float = field(default_factory=0.0)
     end_time: float = field(default_factory=0.0)
 
+
 @dataclass
 class ProcessedMarkers:
     """Dataclass for processed markers.
 
     processed_data : np.ndarray
         Processed EEG data.
-    
+
     labels : np.ndarray
         Labels.
 
@@ -38,6 +40,7 @@ class ProcessedMarkers:
 
     processed_data: np.ndarray = field(default_factory=np.array)
     labels: np.ndarray = field(default_factory=np.array)
+
 
 class Paradigm(ABC):
     def __init__(self, filters=[5, 30], channel_subset=None):

--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -1,6 +1,5 @@
 import numpy as np
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 
 from ..utils.logger import Logger
 from ..signal_processing import bandpass
@@ -8,38 +7,6 @@ from ..signal_processing import bandpass
 # Instantiate a logger for the module at the default level of logging.INFO
 # Logs to bci_essentials.__module__) where __module__ is the name of the module
 logger = Logger(name=__name__)
-
-
-@dataclass
-class StartAndEndTimes:
-    """Dataclass for start and end times of EEG data.
-
-    start_time : float
-        Start time.
-
-    end_time : float
-        End time.
-
-    """
-
-    start_time: float = field(default_factory=0.0)
-    end_time: float = field(default_factory=0.0)
-
-
-@dataclass
-class ProcessedMarkers:
-    """Dataclass for processed markers.
-
-    processed_data : np.ndarray
-        Processed EEG data.
-
-    labels : np.ndarray
-        Labels.
-
-    """
-
-    processed_data: np.ndarray = field(default_factory=np.array)
-    labels: np.ndarray = field(default_factory=np.array)
 
 
 class Paradigm(ABC):

--- a/bci_essentials/paradigm/ssvep_paradigm.py
+++ b/bci_essentials/paradigm/ssvep_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm, StartAndEndTimes
+from .paradigm import Paradigm, StartAndEndTimes, ProcessedMarkers
 
 
 class SsvepParadigm(Paradigm):
@@ -135,7 +135,7 @@ class SsvepParadigm(Paradigm):
                 X = np.concatenate((X, epoch_eeg), axis=0)
 
             y[i] = label
-        return X, y
+        return ProcessedMarkers(X, y)
 
     # TODO: Implement this
     def check_compatibility(self):

--- a/bci_essentials/paradigm/ssvep_paradigm.py
+++ b/bci_essentials/paradigm/ssvep_paradigm.py
@@ -61,10 +61,12 @@ class SsvepParadigm(Paradigm):
 
         Returns
         -------
-        float
-            Start time.
-        float
-            End time.
+        startAndEndTimes : StartAndEndTimes
+            StartAndEndTimes object containing the following:
+                float
+                    Start time.
+                float
+                    End time.
         """
         start_time = timestamps[0] - self.buffer_time
 
@@ -91,10 +93,12 @@ class SsvepParadigm(Paradigm):
 
         Returns
         -------
-        np.array
-            Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
-        np.array
-            Labels. Shape is (n_epochs).
+        processedMarkers : ProcessedMarkers
+            ProcessedMarkers object containing the following:
+                np.array
+                    Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
+                np.array
+                    Labels. Shape is (n_epochs).
         """
 
         # Initialize y

--- a/bci_essentials/paradigm/ssvep_paradigm.py
+++ b/bci_essentials/paradigm/ssvep_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm
+from .paradigm import Paradigm, StartAndEndTimes
 
 
 class SsvepParadigm(Paradigm):
@@ -70,7 +70,7 @@ class SsvepParadigm(Paradigm):
 
         end_time = timestamps[-1] + float(markers[-1].split(",")[-1]) + self.buffer_time
 
-        return start_time, end_time
+        return StartAndEndTimes(start_time, end_time)
 
     def process_markers(self, markers, marker_timestamps, eeg, eeg_timestamps, fsample):
         """

--- a/bci_essentials/paradigm/ssvep_paradigm.py
+++ b/bci_essentials/paradigm/ssvep_paradigm.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .paradigm import Paradigm, StartAndEndTimes, ProcessedMarkers
+from .paradigm import Paradigm
 
 
 class SsvepParadigm(Paradigm):
@@ -61,18 +61,16 @@ class SsvepParadigm(Paradigm):
 
         Returns
         -------
-        startAndEndTimes : StartAndEndTimes
-            StartAndEndTimes object containing the following:
-                float
-                    Start time.
-                float
-                    End time.
+        float
+            Start time.
+        float
+            End time.
         """
         start_time = timestamps[0] - self.buffer_time
 
         end_time = timestamps[-1] + float(markers[-1].split(",")[-1]) + self.buffer_time
 
-        return StartAndEndTimes(start_time, end_time)
+        return start_time, end_time
 
     def process_markers(self, markers, marker_timestamps, eeg, eeg_timestamps, fsample):
         """
@@ -93,12 +91,10 @@ class SsvepParadigm(Paradigm):
 
         Returns
         -------
-        processedMarkers : ProcessedMarkers
-            ProcessedMarkers object containing the following:
-                np.array
-                    Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
-                np.array
-                    Labels. Shape is (n_epochs).
+        np.array
+            Processed EEG data. Shape is (n_epochs, n_channels, n_samples).
+        np.array
+            Labels. Shape is (n_epochs).
         """
 
         # Initialize y
@@ -139,7 +135,7 @@ class SsvepParadigm(Paradigm):
                 X = np.concatenate((X, epoch_eeg), axis=0)
 
             y[i] = label
-        return ProcessedMarkers(X, y)
+        return X, y
 
     # TODO: Implement this
     def check_compatibility(self):

--- a/tests/test_channel_selection.py
+++ b/tests/test_channel_selection.py
@@ -4,6 +4,7 @@ import time
 
 from bci_essentials.utils.logger import Logger  # Logger wrapper
 from bci_essentials.channel_selection import channel_selection_by_method
+from bci_essentials.classification.generic_classifier import KernelResults
 
 from sklearn.model_selection import StratifiedKFold
 from sklearn.pipeline import Pipeline
@@ -73,17 +74,19 @@ def _test_kernel(subX, suby):
 
     Returns
     -------
-    model : classifier
-        The trained classification model.
-    preds : numpy.ndarray
-        The predictions from the model.
-        1D array with the same shape as `suby`.
-    accuracy : float
-        The accuracy of the trained classification model.
-    precision : float
-        The precision of the trained classification model.
-    recall : float
-        The recall of the trained classification model.
+    kernelResults : KernelResults
+        KernelResults object containing the following attributes:
+            model : classifier
+                The trained classification model.
+            preds : numpy.ndarray
+                The predictions from the model.
+                1D array with the same shape as `suby`.
+            accuracy : float
+                The accuracy of the trained classification model.
+            precision : float
+                The precision of the trained classification model.
+            recall : float
+                The recall of the trained classification model.
 
     """
     n_splits = 5
@@ -115,7 +118,7 @@ def _test_kernel(subX, suby):
 
     model = clf
 
-    return model, preds, accuracy, precision, recall
+    return KernelResults(model, preds, accuracy, precision, recall)
 
 
 class TestChannelSelection(unittest.TestCase):

--- a/tests/test_channel_selection.py
+++ b/tests/test_channel_selection.py
@@ -143,7 +143,7 @@ class TestChannelSelection(unittest.TestCase):
         )
         time_end = time.time()
 
-        best_subset = selection_output[0]
+        best_subset = selection_output.best_channel_subset
 
         # Check that the best subset is within the correct range
         self.assertGreaterEqual(len(best_subset), min_channels)
@@ -175,8 +175,8 @@ class TestChannelSelection(unittest.TestCase):
             record_performance=True,
         )
 
-        best_subset = selection_output[0]
-        results_df = selection_output[6]
+        best_subset = selection_output.best_channel_subset
+        results_df = selection_output.results_df
 
         # Check that the best subset is within the correct range
         self.assertGreaterEqual(len(best_subset), min_channels)
@@ -204,8 +204,8 @@ class TestChannelSelection(unittest.TestCase):
             record_performance=True,
         )
 
-        best_subset = selection_output[0]
-        results_df = selection_output[6]
+        best_subset = selection_output.best_channel_subset
+        results_df = selection_output.results_df
 
         # Check that the best subset is within the correct range
         self.assertGreaterEqual(len(best_subset), min_channels)
@@ -239,8 +239,8 @@ class TestChannelSelection(unittest.TestCase):
             record_performance=True,
         )
 
-        best_subset = selection_output[0]
-        results_df = selection_output[6]
+        best_subset = selection_output.best_channel_subset
+        results_df = selection_output.results_df
 
         # Check that the best subset is within the correct range
         self.assertGreaterEqual(len(best_subset), min_channels)
@@ -268,8 +268,8 @@ class TestChannelSelection(unittest.TestCase):
             record_performance=True,
         )
 
-        best_subset = selection_output[0]
-        results_df = selection_output[6]
+        best_subset = selection_output.best_channel_subset
+        results_df = selection_output.results_df
 
         # Check that the best subset is within the correct range
         self.assertGreaterEqual(len(best_subset), min_channels)
@@ -280,9 +280,6 @@ class TestChannelSelection(unittest.TestCase):
         max_channels_tried = int(results_df["N Channels"].max())
         self.assertGreaterEqual(min_channels_tried, min_channels)
         self.assertLessEqual(max_channels_tried, max_channels)
-
-        best_subset = selection_output[0]
-        results_df = selection_output[6]
 
     # Test performance delta
     def test_performance_delta(self):
@@ -308,7 +305,7 @@ class TestChannelSelection(unittest.TestCase):
             record_performance=True,
         )
 
-        results_df = selection_output[6]
+        results_df = selection_output.results_df
 
         # Check that the algorithm didn't check combinations outside of the range
         scores = results_df["Accuracy"]


### PR DESCRIPTION
This is for [B4K-214](https://bci4kids.atlassian.net/browse/B4K-214).

This is to return single objects instead of tuples or separate variables. I used Python `dataclass` to do this, as recommended in the Jira task.

**Changes**

1. **KernelResults Dataclass:** Where applicable, the subclasses of `GenericClassifier` return the `KernelResults` object in the kernel methods, instead of the tuple `(model, preds, accuracy, precision, recall)`.
2. **StartAndEndTimes Dataclass:** The `get_eeg_start_and_end_times(...)` method in the subclasses of `Paradigm` returns the `StartAndEndTimes` object.
3. **ProcessedMarkers Dataclass:** The `process_markers(...)` method in the subclasses of `Paradigm` returns the `ProcessedMarkers` object.
4. **ChannelSelectionOutput Dataclass:** The channel selection methods return the `ChannelSelectionOutput` object.

On the other side of the function calls for each of the above, changes were made to handle the single object returns.