### PR TITLE
Update __init__.py

### DIFF
--- a/bci_essentials/__init__.py
+++ b/bci_essentials/__init__.py
@@ -1,4 +1,12 @@
+# Import submodules to make them discoverable
+from . import classification
+from . import data_tank
+from . import io
+from . import paradigm
+from . import utils
+
 # Instantiate a parent logger for the library at the default level of logging.INFO
 from .utils.logger import Logger
 
 logger = Logger()
+


### PR DESCRIPTION
Improve Python package structure for proper documentation generation

Added imports for all submodules in the root init.py file to make them properly discoverable by documentation tools like pdoc. This follows Python's standard package structure conventions as described in the packaging documentation and ensures all package components are correctly documented.

This change only loads the empty init.py files in each subfolder during initial import, not the actual module contents, so it has negligible performance impact. The actual module code is still lazily loaded only when specifically imported by users.

Previously, only the 'utils' subfolder was being properly documented because it was the only one imported in the root file. This change ensures consistent documentation for all package components.