### PR TITLE
Bug fix for MI duplicating markers online

### DIFF
--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -399,6 +399,9 @@ class BciController:
                 if self.__paradigm.classify_each_epoch:
                     success_flag = self.__process_and_classify()
                     if success_flag is False:
+                        # If the processing failed, then there is not enough EEG
+                        self.event_marker_buffer = []
+                        self.event_timestamp_buffer = []
                         break
 
             # TODO


### PR DESCRIPTION
This fixes the bug where if Bessy MI is running online, it adds the same marker multiple times. This was happening because each Bessy looped looking for more EEG, it would add marker to the event marker buffer. 

I fixed this by reseting the marker buffer to empty if there is not EEG to process. 

Test with any MI Unity scene and window lengths of at least 1 s. Boot up a real or simulated EEG stream and run mi_unity_backend.py. Do iterative training. When python prints the confusion matrix, check that it matches the number of markers that have been sent from Unity so far. (Ex. if Num Train Windows = 3 and Num Selections Before Training = 2 then the first confusion matrix Python returns should sum to 3 x 2 = 6). 