### PR TITLE
Fixed bug where SSVEP takes a long time to process trial

### DIFF
--- a/bci_essentials/paradigm/ssvep_paradigm.py
+++ b/bci_essentials/paradigm/ssvep_paradigm.py
@@ -68,7 +68,7 @@ class SsvepParadigm(Paradigm):
         """
         start_time = timestamps[0] - self.buffer_time
 
-        end_time = timestamps[-1] + float(markers[-1].split(",")[-1]) + self.buffer_time
+        end_time = timestamps[-1] + float(markers[-1].split(",")[3]) + self.buffer_time
 
         return start_time, end_time
 


### PR DESCRIPTION
The bug was because it was reading the last frequency as the length of the window/epoch.

Fixed now.

Test by confirming that SSVEP does not take a very very long time.