### PR TITLE
B4K331 – Fixed broken docstrings

### DIFF
--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -13,8 +13,7 @@ and classified (using one of the `classification` sub-modules).
 
 Classes
 -------
-- `BciController` : For processing continuous data in trials of a defined
-length.
+- `BciController` : For processing continuous data in trials of a defined length.
 
 """
 
@@ -76,6 +75,7 @@ class BciController:
         messenger: Messenger
             Messenger object to handle events from BciController, ex: acknowledging markers and
             predictions.  The default value is None.
+
         """
 
         # Ensure the incoming dependencies are the right type
@@ -140,6 +140,15 @@ class BciController:
     def _pull_data_from_sources(self):
         """Get pull data from EEG and optionally, the marker source.
         This method will fill up the marker_data, bci_controller and corresponding timestamp arrays.
+
+        Parameters
+        ----------
+        `None`
+
+        Returns
+        -------
+        `None`
+
         """
         self.__pull_marker_data_from_source()
         self.__pull_eeg_data_from_source()
@@ -150,7 +159,17 @@ class BciController:
             self._messenger.ping()
 
     def __pull_marker_data_from_source(self):
-        """Pulls marker samples from source, sanity checks and appends to buffer"""
+        """Pulls marker samples from source, sanity checks and appends to buffer.
+        
+        Parameters
+        ----------
+        `None`
+
+        Returns
+        -------
+        `None`
+
+        """
 
         # if there isn't a marker source, abort
         if self.__marker_source is None:
@@ -187,7 +206,17 @@ class BciController:
             )
 
     def __pull_eeg_data_from_source(self):
-        """Pulls eeg samples from source, sanity checks and appends to buffer"""
+        """Pulls eeg samples from source, sanity checks and appends to buffer
+        
+        Parameters
+        ----------
+        `None`
+
+        Returns
+        -------
+        `None`
+
+        """
 
         # read in the data
         eeg, timestamps = self.__eeg_source.get_samples()
@@ -234,17 +263,16 @@ class BciController:
 
         Parameters
         ----------
-            None
+        `None`
 
         Returns
-        ----------
-            success_string : str
-                String indicating if the processing and classification was successful.
-                Potential values are "Success", "Skip", "Wait".
-
-                "Success": The processing and classification was successful.
-                "Skip": EEG is either absent entirely or contains lost packets.
-                "Wait": The processing is waiting for more data.
+        -------
+        success_string : str
+            String indicating if the processing and classification was successful.
+            Potential values are "Success", "Skip", "Wait".
+            - "Success": The processing and classification was successful.
+            - "Skip": EEG is either absent entirely or contains lost packets.
+            - "Wait": The processing is waiting for more data.
 
         """
 
@@ -300,7 +328,17 @@ class BciController:
         return "Success"
 
     def __send_prediction(self, prediction):
-        """Send a prediction to the messenger object."""
+        """Send a prediction to the messenger object.
+
+        Parameters
+        ----------
+        `None`
+
+        Returns
+        -------
+        `None`
+
+        """
         if self._messenger is not None:
             self._messenger.prediction(prediction)
 
@@ -367,8 +405,8 @@ class BciController:
             Maximum number of loops to run, default is `1000000`.
 
         Returns
-        ------
-            None
+        -------
+        `None`
 
         """
 
@@ -406,11 +444,11 @@ class BciController:
 
         Parameters
         ----------
-            None
+        `None`
 
         Returns
-        ------
-            None
+        -------
+        `None`
 
         """
         # read from sources to get new data. This puts command markers in the marker_data array and
@@ -454,12 +492,12 @@ class BciController:
 
         Parameters
         ----------
-            None
+        `None`
 
         Returns
-        ------
-            continue_flag : bool
-                Flag indicating to continue the while loop in step().
+        -------
+        continue_flag : bool
+            Flag indicating to continue the while loop in step().
 
         """
         (
@@ -484,12 +522,12 @@ class BciController:
 
         Parameters
         ----------
-            None
+        `None`
 
         Returns
-        ------
-            continue_flag : bool
-                Flag indicating to continue the while loop in step().
+        -------
+        continue_flag : bool
+            Flag indicating to continue the while loop in step().
 
         """
         logger.debug("Trial started, incrementing marker count and continuing")
@@ -501,13 +539,14 @@ class BciController:
 
         Parameters
         ----------
-            None
+        `None`
 
         Returns
         ------
-            success_flag : bool
-                Flag indicating if the processing and classification was successful.
-                Returns True if not classifying.
+        success_flag : bool
+            Flag indicating if the processing and classification was successful.
+            - Returns `True` if not classifying.
+
         """
         # If we are classifying based on trials, then process the trial,
         if self.__paradigm.classify_each_trial:
@@ -529,12 +568,13 @@ class BciController:
 
         Parameters
         ----------
-            None
+        `None`
 
         Returns
-        ------
-            continue_flag : bool
-                Flag indicating to continue the while loop in step().
+        -------
+        continue_flag : bool
+            Flag indicating to continue the while loop in step().
+
         """
         if self.train_lock is False:
             # Pull the epochs from the data tank and pass them to the classifier
@@ -563,12 +603,13 @@ class BciController:
 
         Parameters
         ----------
-            None
+        `None`
 
         Returns
-        ------
-            continue_flag : bool
-                Flag indicating to continue the while loop in step().
+        -------
+        continue_flag : bool
+            Flag indicating to continue the while loop in step().
+
         """
         # Add the marker to the event marker buffer
         self.event_marker_buffer.append(marker)

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -160,7 +160,7 @@ class BciController:
 
     def __pull_marker_data_from_source(self):
         """Pulls marker samples from source, sanity checks and appends to buffer.
-        
+
         Parameters
         ----------
         `None`
@@ -207,7 +207,7 @@ class BciController:
 
     def __pull_eeg_data_from_source(self):
         """Pulls eeg samples from source, sanity checks and appends to buffer
-        
+
         Parameters
         ----------
         `None`

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -1,12 +1,15 @@
-"""
+"""Channel selection methods for BCI performance improvement.
+
 This module includes functions for selecting channels in order to
 improve BCI performance.
 
+Notes
+-----
 The EEG data input for each function is a set of trials. The data must
 be of the shape `n_trials x n_channels x n_samples`, where:
-- n_trials = number of trials
-- n_channels = number of channels
-- n_samples = number of samples
+    - n_trials = number of trials
+    - n_channels = number of channels 
+    - n_samples = number of samples
 
 """
 
@@ -25,29 +28,25 @@ logger = Logger(name=__name__)
 
 @dataclass
 class ChannelSelectionOutput:
-    """
-    Dataclass to store output from channel selection.
+    """Dataclass to store output from channel selection.
 
+    Parameters
+    ----------
     best_channel_subset : list of `str`
         The best channel subset from the list of 'channel_labels'.
-
     best_model : classifier
         The trained classification model.
-
     best_preds : numpy.ndarray
         The predictions from the model.
-
     best_accuracy : float
         The accuracy of the trained classification model.
-
     best_precision : float
         The precision of the trained classification model.
-
     best_recall : float
         The recall of the trained classification model.
-
     results_df : pandas.DataFrame
         A dataframe containing the performance metrics at each step.
+    
     """
 
     best_channel_subset: list = field(default_factory=list)

--- a/bci_essentials/channel_selection.py
+++ b/bci_essentials/channel_selection.py
@@ -8,7 +8,7 @@ Notes
 The EEG data input for each function is a set of trials. The data must
 be of the shape `n_trials x n_channels x n_samples`, where:
     - n_trials = number of trials
-    - n_channels = number of channels 
+    - n_channels = number of channels
     - n_samples = number of samples
 
 """
@@ -46,7 +46,7 @@ class ChannelSelectionOutput:
         The recall of the trained classification model.
     results_df : pandas.DataFrame
         A dataframe containing the performance metrics at each step.
-    
+
     """
 
     best_channel_subset: list = field(default_factory=list)

--- a/bci_essentials/classification/erp_single_channel_classifier.py
+++ b/bci_essentials/classification/erp_single_channel_classifier.py
@@ -106,7 +106,6 @@ class ErpSingleChannelClassifier(GenericClassifier):
 
         Returns
         -------
-
         `None`
             Models created used in `predict()`.
 

--- a/bci_essentials/io/lsl_sources.py
+++ b/bci_essentials/io/lsl_sources.py
@@ -119,7 +119,7 @@ class LslEegSource(EegSource):
 
 def discover_first_stream(type: str, timeout: float = FOREVER) -> StreamInfo:
     """This helper returns the first stream of the specified type.
-    
+
     If no stream is found, an exception is raised."""
     streams = resolve_byprop("type", type, timeout=timeout)
     return streams[0]
@@ -127,9 +127,9 @@ def discover_first_stream(type: str, timeout: float = FOREVER) -> StreamInfo:
 
 def pull_from_lsl_inlet(inlet: StreamInlet) -> tuple[list[list], list]:
     """StreamInlet.pull_chunk() may return None for samples.
-    
+
     This helper prevents `None` from propagating by converting it into [[]].
-    
+
     If None is detected, the timestamps list is also forced to [].
     """
 

--- a/bci_essentials/io/lsl_sources.py
+++ b/bci_essentials/io/lsl_sources.py
@@ -18,10 +18,8 @@ class LslMarkerSource(MarkerSource):
         ----------
         stream : StreamInfo, *optional*
             Provide stream to use for Markers, if not provided, stream will be discovered.
-
         timeout : float, *optional*
-            How long to wait for marker outlet stream to be discovered.  If no stream
-            is discovered, an Exception is raised.  By default init will wait forever.
+            How long to wait for marker outlet stream to be discovered. If no stream is discovered, an Exception is raised.  By default init will wait forever.
         """
         try:
             if stream is None:
@@ -50,7 +48,6 @@ class LslEegSource(EegSource):
         ----------
         stream : StreamInfo, *optional*
             Provide stream to use for EEG, if not provided, stream will be discovered.
-
         timeout : float, *optional*
             How long to wait for marker stream to be discovered.  If no stream is
             discovered, an Exception is raised.  By defalut init will wait forever.
@@ -121,16 +118,19 @@ class LslEegSource(EegSource):
 
 
 def discover_first_stream(type: str, timeout: float = FOREVER) -> StreamInfo:
-    """This helper returns the first stream of the specified type.  If no stream
-    is found, an exception is raised."""
+    """This helper returns the first stream of the specified type.
+    
+    If no stream is found, an exception is raised."""
     streams = resolve_byprop("type", type, timeout=timeout)
     return streams[0]
 
 
 def pull_from_lsl_inlet(inlet: StreamInlet) -> tuple[list[list], list]:
-    """StreamInlet.pull_chunk() may return None for samples.  This helper prevents None
-    from propagating by converting it into [[]].  If None is detected, the timestamps list
-    is also forced to [].
+    """StreamInlet.pull_chunk() may return None for samples.
+    
+    This helper prevents `None` from propagating by converting it into [[]].
+    
+    If None is detected, the timestamps list is also forced to [].
     """
 
     # read from inlet

--- a/bci_essentials/io/sources.py
+++ b/bci_essentials/io/sources.py
@@ -22,15 +22,16 @@ class MarkerSource(ABC):
 
         Returns
         -------
+        marker_data : tuple(marker, timestemps)
             A tuple of (markers, timestamps):
-
-            markers - A list of samples, where each sample corresponds to a timestamp.
-            Each sample is a list with a single string element that represents a command or
-            a marker.  The string is formatted as follows:
-            command = an arbitrary string, ex: "Trial Started".
-            marker = "paradigm, num options, label number, trial length"
-
-            timestamps - A list timestamps (float in seconds) corresponding to the markers
+            - markers : list[list]
+                - A list of samples, where each sample corresponds to a timestamp.
+                - Each sample is a list with a single string element that represents a command or a marker.
+                - The string is formatted as follows:
+                    - command = an arbitrary string, ex: "Trial Started"
+                    - marker = "paradigm, num options, label number, trial length"
+            - timestamps : list[float]
+                - A list timestamps (float in seconds) corresponding to the markers
         """
         pass
 
@@ -40,9 +41,10 @@ class MarkerSource(ABC):
 
         Returns
         -------
-            The current time correction estimate (float, seconds). This is the number that needs to be added
-            to a time tamp that was remotely generated via local_clock() to map it into
-            the local clock domain of the machine.
+        time_correction : float
+            The current time correction estimate (seconds).
+            - This is the number that needs to be added to a time tamp that was remotely generated via local_clock() to map it into the local clock domain of the machine.
+            
         """
         pass
 
@@ -96,12 +98,13 @@ class EegSource(ABC):
 
         Returns
         -------
-            A tuple of (samples, timestamps):
+        samples_data: tuple(samples, timestamps)
+            - A tuple of (samples, timestamps) where:
+                - samples : list[float]
+                    - A list of samples, where each sample corresponds to a timestamp. Each sample is a list of floats representing the value for each channel of EEG.
+                - timestamps : list[float]
+                    - A list timestamps (float in seconds) corresponding to the samples
 
-            samples - A list of samples, where each sample corresponds to a timestamp.
-            Each sample is a list of floats representing the value for each channel of EEG.
-
-            timestamps - A list timestamps (float in seconds) corresponding to the samples
         """
         pass
 
@@ -111,8 +114,9 @@ class EegSource(ABC):
 
         Returns
         -------
-            The current time correction estimate (float, seconds). This is the number that needs to be added
-            to a time tamp that was remotely generated via local_clock() to map it into
-            the local clock domain of the machine.
+        time_correction : float
+            The current time correction estimate (seconds).
+            - This is the number that needs to be added to a time tamp that was remotely generated via local_clock() to map it into the local clock domain of the machine.
+
         """
         pass

--- a/bci_essentials/io/sources.py
+++ b/bci_essentials/io/sources.py
@@ -44,7 +44,7 @@ class MarkerSource(ABC):
         time_correction : float
             The current time correction estimate (seconds).
             - This is the number that needs to be added to a time tamp that was remotely generated via local_clock() to map it into the local clock domain of the machine.
-            
+
         """
         pass
 

--- a/bci_essentials/io/xdf_sources.py
+++ b/bci_essentials/io/xdf_sources.py
@@ -29,8 +29,13 @@ class XdfMarkerSource(MarkerSource):
         return self.__info["name"][0]
 
     def get_markers(self) -> tuple[list[list], list]:
-        """Read markers and related timestamps from the XDF file.  Returns the contents
-        of the file on the first call to get_markers(), returns empty lists thereafter.
+        """Read markers and related timestamps from the XDF file.
+        
+        Returns
+        -------
+        markers_from_xdf : tuple[markers, timestamps]
+            A tuple of (markers, timestamps). The contents of the file on the first call to get_markers().
+                - Returns empty lists [[],[]] thereafter.
         """
         # return all data on first get
         samples = self.__samples

--- a/bci_essentials/io/xdf_sources.py
+++ b/bci_essentials/io/xdf_sources.py
@@ -30,7 +30,7 @@ class XdfMarkerSource(MarkerSource):
 
     def get_markers(self) -> tuple[list[list], list]:
         """Read markers and related timestamps from the XDF file.
-        
+
         Returns
         -------
         markers_from_xdf : tuple[markers, timestamps]

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -82,6 +82,7 @@ def bandpass(data, f_low, f_high, order, fsample):
         3D (or 2D) array containing data with `float` type.
 
         shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
+
     """
     Wn = [f_low / (fsample / 2), f_high / (fsample / 2)]
     sos = signal.butter(order, Wn, btype="bandpass", output="sos")
@@ -120,6 +121,7 @@ def lowpass(data, f_critical, order, fsample):
         3D (or 2D) array containing data with `float` type.
 
         shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
+
     """
     Wn = f_critical / (fsample / 2)
     sos = signal.butter(order, Wn, btype="lowpass", output="sos")


### PR DESCRIPTION
Addressing JIRA [B4K295](https://bci4kids.atlassian.net/browse/B4K-295) and [B4K331](https://bci4kids.atlassian.net/browse/B4K-331)

Docstrings are supposed to be written in numpy style. Some aren’t, which is preventing the docstrings from being generated with proper formatting.

Went through library and fixed docstrings that were not in numpy format. Major culprit was indendentation. 

E.g. WRONG
```
...
Returns
--------
    value : type
    Description
```

CORRECT:
```
...
Returns
--------
value: type
    Description
```

See numpy style guide here: https://numpydoc.readthedocs.io/en/latest/format.html

# Testing
As this doesn't change any code, just docstrings, there's no functionality to test within bessyPython itself.

However, I have already tested out the docstring generation on the associated repo [APIdocs-for-bci-essentials-python](https://kirtonbcilab.github.io/APIdocs-for-bci-essentials-python/bci_essentials.html).

Thus the "**test**" is to check out the API documentation website: https://kirtonbcilab.github.io/APIdocs-for-bci-essentials-python/bci_essentials.html

You can see that the parameters and everything are being parsed nicely, into lists and all. Previously the parameters and returns were all garbled up into a single "paragraph" that concatenated all the docstrings together