### PR TITLE
354-filtering-before-epochs

### DIFF
--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -33,7 +33,7 @@ class Paradigm(ABC):
         # Do we classify labeled epochs (such as in the case of iterative training)?
         self.classify_labeled_epochs = False
 
-    def _preprocess(self, eeg, fsample, lowcut, highcut):
+    def _preprocess(self, eeg, fsample, lowcut, highcut, order=5):
         """
         Preprocess EEG data with bandpass filter.
 
@@ -47,6 +47,8 @@ class Paradigm(ABC):
             Lower cutoff frequency.
         highcut : float
             Upper cutoff frequency.
+        order : int
+            Order of the filter [n]. Default is 5.
 
         Returns
         -------
@@ -54,7 +56,7 @@ class Paradigm(ABC):
             Bandpassed EEG data. Shape is (n_channels, n_samples).
 
         """
-        new_eeg = bandpass(eeg, lowcut, highcut, 5, fsample)
+        new_eeg = bandpass(eeg, lowcut, highcut, order, fsample)
 
         return new_eeg
 

--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -38,14 +38,14 @@ class Paradigm(ABC):
         Preprocess EEG data with the appropriate filter type:
         - If the data is continuous (i.e., shape is [channels, samples]), a
         bandpass filter is used.
-        - If the data is epoched (i.e., shape is [epoch, channels, samples]), 
+        - If the data is epoched (i.e., shape is [epoch, channels, samples]),
         the time constant (TC) of the highpass filter is computed:
             - If the length of the signal > 5*TC, a bandpass filter is used.
             - If the length of the signal <= 5*TC, a lowpass filter is used.
 
         Reference
         https://www.analogictips.com/an-overview-of-filters-and-their-parameters-part-4-time-and-phase-issues/
-        
+
         Parameters
         ----------
         eeg : np.ndarray
@@ -75,7 +75,7 @@ class Paradigm(ABC):
             logger.debug("Preprocessing epoched EEG")
 
             # Highpass filter settling time
-            tc = 1 / (2*np.pi*lowcut)
+            tc = 1 / (2 * np.pi * lowcut)
             n_samples = eeg.shape[2]
             settling_time = order * tc * 5
 

--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -2,7 +2,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 
 from ..utils.logger import Logger
-from ..signal_processing import bandpass
+from ..signal_processing import bandpass, lowpass
 
 # Instantiate a logger for the module at the default level of logging.INFO
 # Logs to bci_essentials.__module__) where __module__ is the name of the module
@@ -35,12 +35,22 @@ class Paradigm(ABC):
 
     def _preprocess(self, eeg, fsample, lowcut, highcut, order=5):
         """
-        Preprocess EEG data with bandpass filter.
+        Preprocess EEG data with the appropriate filter type:
+        - If the data is continuous (i.e., shape is [channels, samples]), a
+        bandpass filter is used.
+        - If the data is epoched (i.e., shape is [epoch, channels, samples]), 
+        the time constant (TC) of the highpass filter is computed:
+            - If the length of the signal > 5*TC, a bandpass filter is used.
+            - If the length of the signal <= 5*TC, a lowpass filter is used.
 
+        Reference
+        https://www.analogictips.com/an-overview-of-filters-and-their-parameters-part-4-time-and-phase-issues/
+        
         Parameters
         ----------
         eeg : np.ndarray
-            EEG data. Shape is (n_channels, n_samples).
+            EEG data. Shape can be 2D [n_channels, n_samples]
+            or 3D [epochs, n_channels, n_samples].
         fsample : float
             Sampling frequency.
         lowcut : float
@@ -53,12 +63,34 @@ class Paradigm(ABC):
         Returns
         -------
         np.ndarray
-            Bandpassed EEG data. Shape is (n_channels, n_samples).
+            Preprocessed EEG. Shape is the same as `eeg`.
 
         """
-        new_eeg = bandpass(eeg, lowcut, highcut, order, fsample)
 
-        return new_eeg
+        n_dims = len(eeg.shape)
+        if n_dims == 2:
+            logger.debug("Preprocessing continuous EEG")
+            preprocessed_eeg = bandpass(eeg, lowcut, highcut, order, fsample)
+        elif n_dims == 3:
+            logger.debug("Preprocessing epoched EEG")
+
+            # Highpass filter settling time
+            tc = 1 / (2*np.pi*lowcut)
+            n_samples = eeg.shape[2]
+            settling_time = order * tc * 5
+
+            if n_samples > settling_time:
+                logger.debug("Applied bandpass filter to epoched EEG")
+                preprocessed_eeg = bandpass(eeg, lowcut, highcut, order, fsample)
+            else:
+                logger.debug("Applied lowpass filter to epoched EEG")
+                preprocessed_eeg = lowpass(eeg, highcut, order, fsample)
+        else:
+            raise ValueError(
+                "Preprocessing failed. EEG must be 2D (continuous) or 3D (epoched)."
+            )
+
+        return preprocessed_eeg
 
     def package_resting_state_data(
         self, marker_data, marker_timestamps, bci_controller, eeg_timestamps, fsample

--- a/bci_essentials/signal_processing.py
+++ b/bci_essentials/signal_processing.py
@@ -67,9 +67,9 @@ def bandpass(data, f_low, f_high, order, fsample):
 
         shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     f_low : float
-        Lower corner frequency.
+        Lower cut-off frequency.
     f_high : float
-        Upper corner frequency.
+        Upper cut-off frequency.
     order : int
         Order of the filter.
     fsample : float
@@ -92,7 +92,7 @@ def bandpass(data, f_low, f_high, order, fsample):
 
 
 @validate_filter_input
-def lowpass(data, f_critical, order, fsample):
+def lowpass(data, f_cutoff, order, fsample):
     """Lowpass Filter.
 
     Filters out frequencies above f_critical with a Butterworth filter of specific order.
@@ -106,8 +106,8 @@ def lowpass(data, f_critical, order, fsample):
         3D (or 2D) array containing data with `float` type.
 
         shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
-    f_critical : float
-        Critical (cutoff) frequency.
+    f_cutoff : float
+        Cut-off frequency.
     order : int
         Order of the filter.
     fsample : float
@@ -121,7 +121,7 @@ def lowpass(data, f_critical, order, fsample):
 
         shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     """
-    Wn = f_critical / (fsample / 2)
+    Wn = f_cutoff / (fsample / 2)
     sos = signal.butter(order, Wn, btype="lowpass", output="sos")
 
     filtered_data = signal.sosfiltfilt(sos, data, padlen=0)
@@ -130,7 +130,7 @@ def lowpass(data, f_critical, order, fsample):
 
 
 @validate_filter_input
-def highpass(data, f_critical, order, fsample):
+def highpass(data, f_cutoff, order, fsample):
     """Highpass Filter.
 
     Filters out frequencies below f_critical with a Butterworth filter of specific order.
@@ -144,8 +144,8 @@ def highpass(data, f_critical, order, fsample):
         3D (or 2D) array containing data with `float` type.
 
         shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
-    f_critical : float
-        Critical (cutoff) frequency.
+    f_cutoff : float
+        Cut-off frequency.
     order : int
         Order of the filter.
     fsample : float
@@ -159,7 +159,7 @@ def highpass(data, f_critical, order, fsample):
 
         shape = (n_trials, n_channels, n_samples) or (n_channels, n_samples)
     """
-    Wn = f_critical / (fsample / 2)
+    Wn = f_cutoff / (fsample / 2)
     sos = signal.butter(order, Wn, btype="highpass", output="sos")
 
     filtered_data = signal.sosfiltfilt(sos, data, padlen=0)


### PR DESCRIPTION
# Description
Changed the `Paradigm._preprocess()` method to account for shape of the data to be pre-processed and the settling time of the high-pass filters selected. Previous implementation always bandpass the data. However, if the data is epoched, it might not be long enough to accommodate the time constant of the high-pass filter. Thus, causing artifacts.

# Note
Note that this only works for the preprocessing step, the classifiers can do additional filtering (e.g., `ssvep_riemannian_mdm_classifier:160-173`). In this scenarios, it is up to the user to determine whether the additional filtering complies with the signal lenght requirements