### PR TITLE
Changed preprocessing appropriately

### DIFF
--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -36,23 +36,18 @@ class Paradigm(ABC):
     def _preprocess(self, eeg, fsample, lowcut, highcut, order=5):
         """
         Preprocess EEG data with the appropriate filter type:
-        - If the data is continuous (i.e., shape is [channels, samples]), a
-        bandpass filter is used.
-
-        - If the data is epoched (i.e., shape is [epoch, channels, samples]),
-        the filter type depends on the signal length relative to the filter's settling time:
-            - If signal length > settling time: use bandpass filter
-            - If signal length ≤ settling time: use lowpass filter
-            - The settling time is calculated by:
-                1. Compute the time constant (tc) of the highpass filter:
-                    tc = 1 / (2 * π * lowcut)
-                2. Compute the settling time with the formula:
-                    settling_time = tc * 5 * order
-                    - In a first-order system, a rule-of-thumb is that the signal settles in approximately 5 time constants (tc * 5)
-                    - In higher-order filters (e.g., a 5th-order filter set as the default), the settling time incrases linearly with the order of the filter (order * tc * 5)
-                    - This is a simplification, but it provides a good approximation for the settling time of the filter.
-                    - For more details, see the reference below:
-                        https://www.analogictips.com/an-overview-of-filters-and-their-parameters-part-4-time-and-phase-issues/
+        - If signal length > settling time: use bandpass filter
+        - If signal length ≤ settling time: use lowpass filter
+        - The settling time is calculated by:
+            1. Compute the time constant (tc) of the highpass filter:
+                tc = 1 / (2 * π * lowcut)
+            2. Compute the settling time with the formula:
+                settling_time = tc * 5 * order
+                - In a first-order system, a rule-of-thumb is that the signal settles in approximately 5 time constants (tc * 5)
+                - In higher-order filters (e.g., a 5th-order filter set as the default), the settling time incrases linearly with the order of the filter (order * tc * 5)
+                - This is a simplification, but it provides a good approximation for the settling time of the filter.
+                - For more details, see the reference below:
+                    https://www.analogictips.com/an-overview-of-filters-and-their-parameters-part-4-time-and-phase-issues/
 
         Parameters
         ----------
@@ -74,31 +69,21 @@ class Paradigm(ABC):
             Preprocessed EEG. Shape is the same as `eeg`.
 
         """
+        logger.debug("Preprocessing EEG data")
 
-        n_dims = len(eeg.shape)
-        if n_dims == 2:
-            logger.debug("Preprocessing continuous EEG")
+        # Get the length of the signal
+        signal_length = eeg.shape[-1] / fsample
+
+        # Highpass filter settling time
+        tc = 1 / (2 * np.pi * lowcut)
+        settling_time = order * tc * 5
+
+        if signal_length > settling_time:
+            logger.debug("Applied bandpass filter")
             preprocessed_eeg = bandpass(eeg, lowcut, highcut, order, fsample)
-        elif n_dims == 3:
-            logger.debug("Preprocessing epoched EEG")
-
-            # Get the length of the signal
-            signal_length = eeg.shape[2]
-
-            # Highpass filter settling time
-            tc = 1 / (2 * np.pi * lowcut)
-            settling_time = order * tc * 5
-
-            if signal_length > settling_time:
-                logger.debug("Applied bandpass filter to epoched EEG")
-                preprocessed_eeg = bandpass(eeg, lowcut, highcut, order, fsample)
-            else:
-                logger.debug("Applied lowpass filter to epoched EEG")
-                preprocessed_eeg = lowpass(eeg, highcut, order, fsample)
         else:
-            raise ValueError(
-                "Preprocessing failed. EEG must be 2D (continuous) or 3D (epoched)."
-            )
+            logger.debug("Applied lowpass filter")
+            preprocessed_eeg = lowpass(eeg, highcut, order, fsample)
 
         return preprocessed_eeg
 


### PR DESCRIPTION
# Description
The preprocessing in paradigm was applying different filters (i.e., low- or band-pass) depending on whether the signal to process was 2D or 3D. The reasoning for this was that I assumed that a 2D signal would be long enough to accomodate the high-pass filter.

I realized that the epochs in the P300 paradigm are processed concurrently (multiple 2D arrays) rather than simultaneously (3D array). Thus, the bandpass filter was being applied eventhough the signal was not long enough for the time constant to stabilize.

# Implementation
I changed the preprocessing function to consider the time constant of any EEG signal sent regardless if it is 2D or 3D. Right now 3D is not being sent but we could later modify to process all epochs simultaneously (this would speed some things)