### PR TITLE
Auto save epochs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 plugins/FeatureExtractorSSVEP
 session_saves/*.pkl
 *.log
+*.npz

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -215,16 +215,16 @@ class BciController:
                     with open(self.temp_epochs, "rb") as f:
                         X = np.load(f)["X"]
                         y = np.load(f)["y"]
-                        paradigm_str = np.load(f)["paradigm"]
-
-                    # Check if the paradigm is the same
-                    paradigm_str = str(self.__paradigm)
-                    if str(self.__paradigm) != paradigm_str:
+                        paradigm_str = np.load(f)["paradigm"].item()
+                        
+                    # If the paradigm is different, delete the file
+                    if self.__paradigm.paradigm_name != paradigm_str:
                         logger.warning(
                             "Paradigm in temp_epochs file does not match current paradigm. Deleting file."
                         )
                         os.remove(self.temp_epochs)
 
+                    # If the paradigm is the same, then add the epochs to the data tank
                     else:
                         # Add the epochs to the data tank
                         self.__data_tank.add_epochs(X, y)
@@ -567,8 +567,7 @@ class BciController:
 
         # Save epochs to temp_epochs file
         if self.online:
-            paradigm_str = str(self.__paradigm)
-            print(paradigm_str)
+            paradigm_str = self.__paradigm.paradigm_name
             with open(self.temp_epochs, "wb") as f:
                 np.savez(f, X=X, y=y, paradigm=paradigm_str)
         

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -726,12 +726,14 @@ class BciController:
                 prediction,
             )
 
-    def __load_temp_epochs_if_available(self):
+    def __load_temp_epochs_if_available(self, reload_data_time: int = 300):
         """Load temp_epochs if available and valid.
 
         Parameters
         ----------
-        `None`
+        reload_data_time : int, *optional*
+            Time in seconds of the last temp_epochs file to reload the data from.
+            Default is `300` seconds (5 minutes).
 
         Returns
         -------
@@ -745,8 +747,8 @@ class BciController:
         if not os.path.exists(self.temp_epochs):
             return
 
-        # If temp_epochs is older than 5 minutes, delete it
-        if os.path.getmtime(self.temp_epochs) < (time.time() - 300):
+        # If temp_epochs is older than `reload_data_time`, delete it
+        if os.path.getmtime(self.temp_epochs) < (time.time() - reload_data_time):
             os.remove(self.temp_epochs)
             logger.info("Deleted old temp_epochs file.")
             return

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -728,7 +728,7 @@ class BciController:
 
     def __load_temp_epochs_if_available(self):
         """Load temp_epochs if available and valid.
-        
+
         Parameters
         ----------
         `None`
@@ -775,4 +775,3 @@ class BciController:
         # If there are epochs in the data tank, then train the classifier
         if len(self.__data_tank.labels) > 0:
             self.__update_and_train_classifier()
-

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -531,11 +531,13 @@ class BciController:
             self.fsample,
         )
 
+        sum_new_labeled_trials = np.sum(y != -1)
+
         # Add the epochs to the data tank
         self.__data_tank.add_epochs(X, y)
 
         # Save epochs to temp_epochs file
-        if self.online:
+        if self.online and sum_new_labeled_trials > 0:
             paradigm_str = self.__paradigm.paradigm_name
 
             with open(self.temp_epochs, "wb") as f:

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -227,15 +227,14 @@ class BciController:
                     # If the paradigm is the same, then add the epochs to the data tank
                     else:
                         # Add the epochs to the data tank
+                        logger.info("Loading epochs from temp_epochs file.")
+                        logger.info("X shape: %s", X.shape)
+                        logger.info("y shape: %s", y.shape)
                         self.__data_tank.add_epochs(X, y)
 
                         # If there are epochs in the data tank, then train the classifier
                         if len(self.__data_tank.labels) > 0:
                             self.__update_and_train_classifier()
-
-        # If there are epochs in the data tank, then train the classifier
-        if len(self.__data_tank.labels) > 0:
-            self.__update_and_train_classifier()
 
     def step(self):
         """Runs a single BciController processing step.
@@ -565,15 +564,18 @@ class BciController:
             self.fsample,
         )
 
+        # Add the epochs to the data tank
+        self.__data_tank.add_epochs(X, y)
+
         # Save epochs to temp_epochs file
         if self.online:
             paradigm_str = self.__paradigm.paradigm_name
+            
             with open(self.temp_epochs, "wb") as f:
-                np.savez(f, X=X, y=y, paradigm=paradigm_str)
-        
-
-        # Add the epochs to the data tank
-        self.__data_tank.add_epochs(X, y)
+                np.savez(f, 
+                         X=self.__data_tank.epochs, 
+                         y=self.__data_tank.labels, 
+                         paradigm=paradigm_str)
 
         # If either there are no labels OR iterative training is on, then make a prediction
         if self.train_complete:

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -200,7 +200,7 @@ class BciController:
         self.online_selections = []
 
         # Check for a temp_epochs file
-        if online == True:
+        if online:
             self.temp_epochs = os.path.join(
                 os.path.dirname(os.path.dirname(__file__)), "temp_epochs.npz"
             )

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -195,6 +195,7 @@ class BciController:
         self.online = online
         self.train_complete = train_complete
         self.train_lock = train_lock
+        self.auto_save_epochs = auto_save_epochs
 
         # initialize the numbers of markers and trials to zero
         self.marker_count = 0

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -570,7 +570,8 @@ class BciController:
             paradigm_str = str(self.__paradigm)
             print(paradigm_str)
             with open(self.temp_epochs, "wb") as f:
-                np.savez(f, X=self.epochs, y=self.labels, paradigm=paradigm_str)
+                np.savez(f, X=X, y=y, paradigm=paradigm_str)
+        
 
         # Add the epochs to the data tank
         self.__data_tank.add_epochs(X, y)

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -216,7 +216,7 @@ class BciController:
                         X = np.load(f)["X"]
                         y = np.load(f)["y"]
                         paradigm_str = np.load(f)["paradigm"].item()
-                        
+
                     # If the paradigm is different, delete the file
                     if self.__paradigm.paradigm_name != paradigm_str:
                         logger.warning(
@@ -570,12 +570,14 @@ class BciController:
         # Save epochs to temp_epochs file
         if self.online:
             paradigm_str = self.__paradigm.paradigm_name
-            
+
             with open(self.temp_epochs, "wb") as f:
-                np.savez(f, 
-                         X=self.__data_tank.epochs, 
-                         y=self.__data_tank.labels, 
-                         paradigm=paradigm_str)
+                np.savez(
+                    f,
+                    X=self.__data_tank.epochs,
+                    y=self.__data_tank.labels,
+                    paradigm=paradigm_str,
+                )
 
         # If either there are no labels OR iterative training is on, then make a prediction
         if self.train_complete:

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -201,40 +201,7 @@ class BciController:
 
         # Check for a temp_epochs file
         if online:
-            self.temp_epochs = os.path.join(
-                os.path.dirname(os.path.dirname(__file__)), "temp_epochs.npz"
-            )
-            if os.path.exists(self.temp_epochs):
-                # If temp_epochs older than 10 minutes, delete it
-                if os.path.getmtime(self.temp_epochs) < (time.time() - 300):
-                    os.remove(self.temp_epochs)
-                    logger.info("Deleted old temp_epochs file.")
-
-                else:
-                    # Load the temp_epochs file
-                    with open(self.temp_epochs, "rb") as f:
-                        X = np.load(f)["X"]
-                        y = np.load(f)["y"]
-                        paradigm_str = np.load(f)["paradigm"].item()
-
-                    # If the paradigm is different, delete the file
-                    if self.__paradigm.paradigm_name != paradigm_str:
-                        logger.warning(
-                            "Paradigm in temp_epochs file does not match current paradigm. Deleting file."
-                        )
-                        os.remove(self.temp_epochs)
-
-                    # If the paradigm is the same, then add the epochs to the data tank
-                    else:
-                        # Add the epochs to the data tank
-                        logger.info("Loading epochs from temp_epochs file.")
-                        logger.info("X shape: %s", X.shape)
-                        logger.info("y shape: %s", y.shape)
-                        self.__data_tank.add_epochs(X, y)
-
-                        # If there are epochs in the data tank, then train the classifier
-                        if len(self.__data_tank.labels) > 0:
-                            self.__update_and_train_classifier()
+            self.__load_temp_epochs_if_available()
 
     def step(self):
         """Runs a single BciController processing step.
@@ -758,3 +725,54 @@ class BciController:
                 "Messenger not available (self._messenger is None). Prediction not sent: %s",
                 prediction,
             )
+
+    def __load_temp_epochs_if_available(self):
+        """Load temp_epochs if available and valid.
+        
+        Parameters
+        ----------
+        `None`
+
+        Returns
+        -------
+        `None`
+
+        """
+        self.temp_epochs = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "temp_epochs.npz"
+        )
+
+        if not os.path.exists(self.temp_epochs):
+            return
+
+        # If temp_epochs is older than 5 minutes, delete it
+        if os.path.getmtime(self.temp_epochs) < (time.time() - 300):
+            os.remove(self.temp_epochs)
+            logger.info("Deleted old temp_epochs file.")
+            return
+
+        # Load the temp_epochs file
+        with open(self.temp_epochs, "rb") as f:
+            npz = np.load(f, allow_pickle=True)
+            X = npz["X"]
+            y = npz["y"]
+            paradigm_str = npz["paradigm"].item()
+
+        # If the paradigm is different, delete the file
+        if self.__paradigm.paradigm_name != paradigm_str:
+            logger.warning(
+                "Paradigm in temp_epochs file does not match current paradigm. Deleting file."
+            )
+            os.remove(self.temp_epochs)
+            return
+
+        # If the paradigm is the same, then add the epochs to the data tank
+        logger.info("Loading epochs from temp_epochs file.")
+        logger.info("X shape: %s", X.shape)
+        logger.info("y shape: %s", y.shape)
+        self.__data_tank.add_epochs(X, y)
+
+        # If there are epochs in the data tank, then train the classifier
+        if len(self.__data_tank.labels) > 0:
+            self.__update_and_train_classifier()
+

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -148,6 +148,7 @@ class BciController:
         online=True,
         train_complete=False,
         train_lock=False,
+        auto_save_epochs=True,
     ):
         """Configure processing loop.
 
@@ -180,6 +181,11 @@ class BciController:
             - `True`: The classifier is locked.
             - `False`: The classifier is not locked.
             - Default is `False`.
+        auto_save_epochs : bool, *optional*
+            Flag to indicate if labeled epochs should be automatically saved to a temp file so they can be reloaded if Bessy crashes.
+            - `True`: Epochs will be saved to a temp file.
+            - `False`: Epochs will not be saved to a temp file.
+
 
         Returns
         -------
@@ -537,7 +543,7 @@ class BciController:
         self.__data_tank.add_epochs(X, y)
 
         # Save epochs to temp_epochs file
-        if self.online and sum_new_labeled_trials > 0:
+        if self.auto_save_epochs and self.online and sum_new_labeled_trials > 0:
             paradigm_str = self.__paradigm.paradigm_name
 
             with open(self.temp_epochs, "wb") as f:

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -18,6 +18,7 @@ Classes
 """
 
 import time
+import os
 import numpy as np
 from enum import Enum
 
@@ -197,6 +198,40 @@ class BciController:
         self.num_online_selections = 0
         self.online_selection_indices = []
         self.online_selections = []
+
+        # Check for a temp_epochs file
+        if online == True:
+            self.temp_epochs = os.path.join(
+                os.path.dirname(os.path.dirname(__file__)), "temp_epochs.npz"
+            )
+            if os.path.exists(self.temp_epochs):
+                # If temp_epochs older than 10 minutes, delete it
+                if os.path.getmtime(self.temp_epochs) < (time.time() - 300):
+                    os.remove(self.temp_epochs)
+                    logger.info("Deleted old temp_epochs file.")
+
+                else:
+                    # Load the temp_epochs file
+                    with open(self.temp_epochs, "rb") as f:
+                        X = np.load(f)["X"]
+                        y = np.load(f)["y"]
+                        paradigm_str = np.load(f)["paradigm"]
+
+                    # Check if the paradigm is the same
+                    paradigm_str = str(self.__paradigm)
+                    if str(self.__paradigm) != paradigm_str:
+                        logger.warning(
+                            "Paradigm in temp_epochs file does not match current paradigm. Deleting file."
+                        )
+                        os.remove(self.temp_epochs)
+
+                    else:
+                        # Add the epochs to the data tank
+                        self.__data_tank.add_epochs(X, y)
+
+                        # If there are epochs in the data tank, then train the classifier
+                        if len(self.__data_tank.labels) > 0:
+                            self.__update_and_train_classifier()
 
         # If there are epochs in the data tank, then train the classifier
         if len(self.__data_tank.labels) > 0:
@@ -529,6 +564,13 @@ class BciController:
             timestamps,
             self.fsample,
         )
+
+        # Save epochs to temp_epochs file
+        if self.online:
+            paradigm_str = str(self.__paradigm)
+            print(paradigm_str)
+            with open(self.temp_epochs, "wb") as f:
+                np.savez(f, X=self.epochs, y=self.labels, paradigm=paradigm_str)
 
         # Add the epochs to the data tank
         self.__data_tank.add_epochs(X, y)

--- a/bci_essentials/bci_controller.py
+++ b/bci_essentials/bci_controller.py
@@ -198,6 +198,10 @@ class BciController:
         self.online_selection_indices = []
         self.online_selections = []
 
+        # If there are epochs in the data tank, then train the classifier
+        if len(self.__data_tank.labels) > 0:
+            self.__update_and_train_classifier()
+
     def step(self):
         """Runs a single BciController processing step.
 

--- a/bci_essentials/data_tank/data_tank.py
+++ b/bci_essentials/data_tank/data_tank.py
@@ -1,4 +1,6 @@
 import numpy as np
+import os
+import time
 from ..utils.logger import Logger  # Logger wrapper
 
 # Instantiate a logger for the module at the default level of logging.INFO
@@ -38,6 +40,23 @@ class DataTank:
         # Keep track of how many epochs have been sent, so it is possible to only send new ones
         self.epochs_sent = 0
         self.epochs = np.zeros((0, 0))
+        self.labels = np.zeros((0), dtype=str)
+
+        # Check for a temp_epochs file
+        self.temp_epochs = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "temp_epochs.npz"
+        )
+        if os.path.exists(self.temp_epochs):
+            # If temp_epochs older than 10 minutes, delete it
+            if os.path.getmtime(self.temp_epochs) < (time.time() - 300):
+                os.remove(self.temp_epochs)
+                logger.info("Deleted old temp_epochs file.")
+
+            else:
+                # Load the temp_epochs file
+                with open(self.temp_epochs, "rb") as f:
+                    self.epochs = np.load(f)["X"]
+                    self.labels = np.load(f)["y"]
 
     def set_source_data(
         self, headset_string, fsample, n_channels, ch_types, ch_units, channel_labels
@@ -183,6 +202,10 @@ class DataTank:
             else:
                 self.epochs = np.concatenate((self.epochs, np.array(X)))
                 self.labels = np.concatenate((self.labels, np.array(y)))
+
+        # Save the epochs to a temp file
+        with open(self.temp_epochs, "wb") as f:
+            np.savez(f, X=self.epochs, y=self.labels)
 
     def get_epochs(self, latest=False):
         """

--- a/bci_essentials/data_tank/data_tank.py
+++ b/bci_essentials/data_tank/data_tank.py
@@ -40,7 +40,6 @@ class DataTank:
         self.epochs = np.zeros((0, 0))
         self.labels = np.array([], dtype=str)
 
-
     def set_source_data(
         self, headset_string, fsample, n_channels, ch_types, ch_units, channel_labels
     ):

--- a/bci_essentials/data_tank/data_tank.py
+++ b/bci_essentials/data_tank/data_tank.py
@@ -1,6 +1,4 @@
 import numpy as np
-import os
-import time
 from ..utils.logger import Logger  # Logger wrapper
 
 # Instantiate a logger for the module at the default level of logging.INFO
@@ -41,22 +39,6 @@ class DataTank:
         self.epochs_sent = 0
         self.epochs = np.zeros((0, 0))
         self.labels = np.zeros((0), dtype=str)
-
-        # Check for a temp_epochs file
-        self.temp_epochs = os.path.join(
-            os.path.dirname(os.path.dirname(__file__)), "temp_epochs.npz"
-        )
-        if os.path.exists(self.temp_epochs):
-            # If temp_epochs older than 10 minutes, delete it
-            if os.path.getmtime(self.temp_epochs) < (time.time() - 300):
-                os.remove(self.temp_epochs)
-                logger.info("Deleted old temp_epochs file.")
-
-            else:
-                # Load the temp_epochs file
-                with open(self.temp_epochs, "rb") as f:
-                    self.epochs = np.load(f)["X"]
-                    self.labels = np.load(f)["y"]
 
     def set_source_data(
         self, headset_string, fsample, n_channels, ch_types, ch_units, channel_labels
@@ -202,10 +184,6 @@ class DataTank:
             else:
                 self.epochs = np.concatenate((self.epochs, np.array(X)))
                 self.labels = np.concatenate((self.labels, np.array(y)))
-
-        # Save the epochs to a temp file
-        with open(self.temp_epochs, "wb") as f:
-            np.savez(f, X=self.epochs, y=self.labels)
 
     def get_epochs(self, latest=False):
         """

--- a/bci_essentials/data_tank/data_tank.py
+++ b/bci_essentials/data_tank/data_tank.py
@@ -38,7 +38,8 @@ class DataTank:
         # Keep track of how many epochs have been sent, so it is possible to only send new ones
         self.epochs_sent = 0
         self.epochs = np.zeros((0, 0))
-        self.labels = np.zeros((0), dtype=str)
+        self.labels = np.array([], dtype=str)
+
 
     def set_source_data(
         self, headset_string, fsample, n_channels, ch_types, ch_units, channel_labels

--- a/bci_essentials/paradigm/mi_paradigm.py
+++ b/bci_essentials/paradigm/mi_paradigm.py
@@ -49,6 +49,8 @@ class MiParadigm(Paradigm):
 
         self.buffer_time = buffer_time
 
+        self.paradigm_name = "MI"
+
     def get_eeg_start_and_end_times(self, markers, timestamps):
         """
         Get the start and end times of the EEG data based on the markers.

--- a/bci_essentials/paradigm/p300_paradigm.py
+++ b/bci_essentials/paradigm/p300_paradigm.py
@@ -54,6 +54,8 @@ class P300Paradigm(Paradigm):
 
         self.buffer_time = buffer_time
 
+        self.paradigm_name = "P300"
+
     def get_eeg_start_and_end_times(self, markers, timestamps):
         """
         Get the start and end times of the EEG data based on the markers.

--- a/bci_essentials/paradigm/paradigm.py
+++ b/bci_essentials/paradigm/paradigm.py
@@ -33,6 +33,8 @@ class Paradigm(ABC):
         # Do we classify labeled epochs (such as in the case of iterative training)?
         self.classify_labeled_epochs = False
 
+        self.paradigm_name = "Generic"
+
     def _preprocess(self, eeg, fsample, lowcut, highcut, order=5):
         """
         Preprocess EEG data with the appropriate filter type:

--- a/bci_essentials/paradigm/ssvep_paradigm.py
+++ b/bci_essentials/paradigm/ssvep_paradigm.py
@@ -48,6 +48,8 @@ class SsvepParadigm(Paradigm):
 
         self.buffer_time = buffer_time
 
+        self.paradigm_name = "SSVEP"
+
     def get_eeg_start_and_end_times(self, markers, timestamps):
         """
         Get the start and end times of the EEG data based on the markers.


### PR DESCRIPTION
Added auto saving of epochs to a temp .npz file.

This means that if you session crashes, you can rescue your previously collected training epochs and not have to train again.

This implementation is only based on time. If there is a temp_epochs file from less than 5 minutes ago, it loads those epochs. Any older and it deletes the temp_epochs file and continues as normal. Temp_epochs is overwritten every time an epoch is added to the data tank.

Test by running MI, P300, and SSVEP online with simulated or real EEG. Quit python partway through training. Next time you load up python it should reload the epochs. You can then restart training to add more epochs and train with old plus new epochs or use it online right away if there were enough epochs to train a classifier. When changing between paradigms, it should delete the old temp file on startup.